### PR TITLE
docs: ack branch-and-release-flow runbook 2026-05-06a

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Each session, check the top entry of each source against the codes below. If new
 | Source | Last acknowledged |
 |---|---|
 | [comms conventions](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/comms-conventions.md) | 2026-05-05a |
-| [branch & release flow](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/branch-and-release-flow.md) | 2026-05-05a |
+| [branch & release flow](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/branch-and-release-flow.md) | 2026-05-06a |
 | [doc conventions](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/doc-conventions.md) | 2026-05-05a |
 | [technical standards](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/technical-standards.md) | 2026-05-05a |
 | [shared/ file pool](https://github.com/gezmodean-wow/cogworks/blob/main/shared/VERSION) | 2026-05-05a — `bash scripts/sync-standards.sh check` |


### PR DESCRIPTION
## Summary
- Bumps `branch & release flow` ack code in `CLAUDE.md` from `2026-05-05a` → `2026-05-06a`
- Acknowledges the runbook entry that formalized the `<type>/<COG-N>-<slug>` branch-naming convention
- First proper-flow PR after v0.12.0 — warming up branch → PR → squash-merge for v0.13 work

## Test plan
- [ ] Diff is the single ack-code line bump in `CLAUDE.md`
- [ ] No code, no addon files, no version touched
- [ ] Squash-merge target: `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)