### PR TITLE
refactor(FQ-143): Phase A1 — delegate item-key + color/format helpers to Cogworks

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -125,54 +125,16 @@ end
 -- Item Key Generation
 --------------------------
 
--- Matches FlippingPal's GetItemKey format: "itemID;bonusIDs;modifiers"
+-- Item-key construction + WoW-itemString conversion delegate to Cogworks-1.0
+-- (Items.lua) so all suite cogs share one canonical implementation. Format
+-- matches FlippingPal's "itemID;bonusIDs;modifiers" shape; Cogworks owns the
+-- modifier-9 (item level) handling.
 function ns:MakeItemKey(itemID, bonusIDs, modifiers)
-    return string.format("%s;%s;%s", tostring(itemID), bonusIDs or "", modifiers or "")
+    return ns.cw:MakeItemKey(itemID, bonusIDs, modifiers)
 end
 
--- Convert an itemKey ("itemID;bonusIDs;modifiers") to a WoW item string
--- suitable for GameTooltip:SetHyperlink(). Returns nil for pets or invalid keys.
 function ns:ItemKeyToItemString(itemKey)
-    if not itemKey or itemKey == "" then return nil end
-    if itemKey:find("^pet:") then return nil end -- pets use battlepet: links
-
-    local idStr, bonusStr, modStr = strsplit(";", itemKey)
-    local numID = tonumber(idStr)
-    if not numID or numID <= 0 then return nil end
-
-    -- WoW item string positions:
-    --   item:itemID:enchantID:gemID1:gemID2:gemID3:gemID4:suffixID:uniqueID:
-    --     linkLevel:specID:modifiersMask:itemContext:numBonusIDs:b1:b2:...:
-    --     numModifiers:modType1:modValue1:...
-    -- That's 11 empty fields between itemID and numBonusIDs (positions 3-13).
-    -- Older versions of this builder used only 10 empties, which made the
-    -- bonus count land in the itemContext slot and the bonus IDs themselves
-    -- shift left — SetHyperlink would silently render the base item (or
-    -- nothing at all), masking ilvl variants in tooltips.
-    local parts = {"item", idStr, "", "", "", "", "", "", "", "", "", "", ""}
-    -- Bonus IDs
-    if bonusStr and bonusStr ~= "" then
-        local bonuses = {strsplit(":", bonusStr)}
-        table.insert(parts, tostring(#bonuses))
-        for _, b in ipairs(bonuses) do
-            table.insert(parts, b)
-        end
-    else
-        table.insert(parts, "0")
-    end
-    -- Modifiers (e.g., "9=85" → modifier type 9, value 85)
-    if modStr and modStr ~= "" then
-        local mods = {strsplit(":", modStr)}
-        table.insert(parts, tostring(#mods))
-        for _, m in ipairs(mods) do
-            local k, v = m:match("^(%d+)=(%d+)$")
-            if k and v then
-                table.insert(parts, k)
-                table.insert(parts, v)
-            end
-        end
-    end
-    return table.concat(parts, ":")
+    return ns.cw:ItemKeyToItemString(itemKey)
 end
 
 -- Set up GameTooltip for an item, preferring the bonus-ID-decorated
@@ -240,56 +202,10 @@ function ns:MakeImportKey(itemKey, itemName, targetRealm, ilvl)
     return base:lower() .. ilvlSuffix .. "|" .. realm
 end
 
--- Parse item link to extract itemID, bonusIDs, modifiers
--- Replicates FlippingPal's ParseItemLink logic for compatibility
+-- Parse a WoW item link into (itemID, bonusIDs, modifiers) — battle-pet links
+-- return ("pet:<speciesID>", "q<quality>", ""). Delegates to Cogworks-1.0.
 function ns:ParseItemLink(itemLink)
-    if not itemLink then return nil end
-
-    -- Handle battle pets: |Hbattlepet:speciesID:level:quality:...|h[Name]|h
-    local speciesID = itemLink:match("|Hbattlepet:(%d+)")
-    if speciesID then
-        local petQuality = itemLink:match("|Hbattlepet:%d+:%d+:(%d+)")
-        return "pet:" .. speciesID, "q" .. (petQuality or "0"), ""
-    end
-
-    -- Standard items
-    local itemString = itemLink:match("item[%-?%d:]+")
-    if not itemString then return nil end
-
-    local parts = {strsplit(":", itemString)}
-    local itemID = parts[2]
-    if not itemID or itemID == "" then return nil end
-
-    local bonusIDs = ""
-    local modifiers = ""
-
-    if #parts >= 14 then
-        local numBonusIDs = tonumber(parts[14]) or 0
-        local bonusList = {}
-        for i = 1, numBonusIDs do
-            local bid = parts[14 + i]
-            if bid and bid ~= "" then
-                table.insert(bonusList, bid)
-            end
-        end
-        bonusIDs = table.concat(bonusList, ":")
-
-        local modStart = 14 + numBonusIDs + 1
-        if #parts >= modStart then
-            local numMods = tonumber(parts[modStart]) or 0
-            local modList = {}
-            for i = 1, numMods do
-                local mType = parts[modStart + (i * 2) - 1]
-                local mVal  = parts[modStart + (i * 2)]
-                if mType and mVal and mType ~= "" and mVal ~= "" and mType == "9" then
-                    table.insert(modList, mType .. "=" .. mVal)
-                end
-            end
-            modifiers = table.concat(modList, ":")
-        end
-    end
-
-    return itemID, bonusIDs, modifiers
+    return ns.cw:ParseItemLink(itemLink)
 end
 
 --------------------------

--- a/UI/MinimapButton.lua
+++ b/UI/MinimapButton.lua
@@ -1,15 +1,8 @@
 -- UI/MinimapButton.lua
--- Minimap icon using LibDBIcon-1.0 (standard library used by TSM, WeakAuras, etc.)
--- Supports icon managers, minimap drawers, and all minimap shapes automatically.
---
--- Chrome: when Cogworks-1.0 v0.6.0+ is embedded, the button is registered via
--- Cogworks:RegisterCogMinimapButton, which wraps LibDBIcon:Register and adds
--- the suite-shared brass gear-ring border. Per-cog identity comes from the
--- inner glyph (Art/fq-inner.tga — gold FQ on deep purple).
---
--- Soft-degrade: if an older Cogworks (or none) is loaded, falls back to a
--- direct LibDBIcon:Register so the button keeps working with its default
--- circular border. No regression for users on stale installs.
+-- Minimap icon registered via Cogworks-1.0's RegisterCogMinimapButton, which
+-- wraps LibDBIcon-1.0 and adds the suite-shared brass gear-ring border.
+-- Per-cog identity comes from the inner glyph (Art/fq-inner.tga — gold FQ on
+-- deep purple).
 local addonName, ns = ...
 
 local UI = ns.UI
@@ -99,15 +92,7 @@ local function RegisterIcon()
     local broker = LDB:NewDataObject("FlipQueue", dataObject)
 
     local Cogworks = LibStub:GetLibrary("Cogworks-1.0", true)
-    if Cogworks and Cogworks.RegisterCogMinimapButton then
-        -- Cogworks wraps LibDBIcon:Register and adds the suite-shared gear ring.
-        Cogworks:RegisterCogMinimapButton("FlipQueue", broker, ns.db.settings.minimapIcon)
-    else
-        -- Soft-degrade: older embedded Cogworks (< v0.6.0) or library absent.
-        -- Falls back to LibDBIcon direct registration; user sees the default
-        -- circular border with no gear ring, but no regression.
-        LDBIcon:Register("FlipQueue", broker, ns.db.settings.minimapIcon)
-    end
+    Cogworks:RegisterCogMinimapButton("FlipQueue", broker, ns.db.settings.minimapIcon)
     registered = true
 end
 

--- a/UI/Shared.lua
+++ b/UI/Shared.lua
@@ -5,31 +5,12 @@ local addonName, ns = ...
 local UI = ns.UI
 
 -- ==========================================
--- ITEM QUALITY COLORS
+-- COLOR HELPERS
 -- ==========================================
-
-local QUALITY_COLORS = {
-    Poor      = "9d9d9d",
-    Common    = "ffffff",
-    Uncommon  = "1eff00",
-    Rare      = "0070dd",
-    Epic      = "a335ee",
-    Legendary = "ff8000",
-    Artifact  = "e6cc80",
-    Heirloom  = "00ccff",
-}
-
--- WoW Enum.ItemQuality numeric -> color
-local QUALITY_NUM_COLORS = {
-    [0] = "9d9d9d", -- Poor
-    [1] = "ffffff", -- Common
-    [2] = "1eff00", -- Uncommon
-    [3] = "0070dd", -- Rare
-    [4] = "a335ee", -- Epic
-    [5] = "ff8000", -- Legendary
-    [6] = "e6cc80", -- Artifact
-    [7] = "00ccff", -- Heirloom
-}
+-- Quality-color and gold-format helpers delegate to Cogworks-1.0 (Text.lua)
+-- so all suite cogs render these the same way. CLASS_COLORS stays local for
+-- now — its consumers do direct table lookups (CLASS_COLORS[class]) and
+-- migrating those call sites belongs with the Phase B page rewrites.
 
 -- WoW class colors for display
 local CLASS_COLORS = {
@@ -44,18 +25,8 @@ local CLASS_COLORS = {
 -- UTILITY FUNCTIONS
 -- ==========================================
 
--- Colorize a name by quality (string name like "Rare" or numeric 3)
 local function QualityColorName(name, quality)
-    local color
-    if type(quality) == "number" then
-        color = QUALITY_NUM_COLORS[quality]
-    elseif type(quality) == "string" and quality ~= "" then
-        color = QUALITY_COLORS[quality]
-    end
-    if color then
-        return "|cff" .. color .. name .. "|r"
-    end
-    return name
+    return ns.cw:QualityColorName(name, quality)
 end
 
 -- Look up icon, quality, and resolved numeric ID for an item
@@ -134,16 +105,8 @@ local function LookupItemInfo(itemID, itemKey, itemName)
     return icon, quality, resolvedID
 end
 
--- Format gold value for display
--- Estimates are truncated to whole numbers (no decimals) by design — the
--- todo-list group headers show approximate gold with a "~" prefix, and
--- fractional gold amounts make that noisier than it needs to be.
 local function FormatGoldValue(totalGold)
-    if not totalGold or totalGold <= 0 then return "" end
-    if totalGold >= 1000 then
-        return math.floor(totalGold / 1000) .. "k gold"
-    end
-    return math.floor(totalGold) .. " gold"
+    return ns.cw:FormatGoldValue(totalGold)
 end
 
 -- ==========================================


### PR DESCRIPTION
## Summary

First Phase A landing for FQ#143 — three mechanical swaps that delegate duplicated helpers to Cogworks-1.0 v0.13.2 (already vendored).

- **`UI/MinimapButton.lua`** — strip dead Cogworks-absent fallback. Library is vendored, fallback is unreachable.
- **`Core.lua`** — `ns:MakeItemKey`, `ns:ItemKeyToItemString`, `ns:ParseItemLink` thin-shim through `ns.cw` (Cogworks Items.lua). ~95 LOC of duplicated parsing logic gone.
- **`UI/Shared.lua`** — local `QualityColorName` + `FormatGoldValue` shim through Cogworks Text.lua. UI exports preserved so the ~30 call sites across pages keep working unchanged.

**Net: −136 / +21 lines across 3 files.**

## What's deliberately deferred

- `ns:ResolveItemID` + `ns:ItemsMatch` need a callback bridge to FQ's inventory walks — Phase A2.
- `UI/SlashCommands.lua` (1528 LOC) → `cw:RegisterSlashCommands` rewrite deserves its own PR (FQ#143 "Slash dispatcher" milestone).
- Toast adoption needs a survey of ~248 `ns:Print` call sites — own focused pass.
- `CLASS_COLORS` table stays local; its 20+ consumers do direct table lookups and migrating them belongs with the Phase B page rewrites.

## Test plan

- [ ] `luac -p` clean on all three files (verified locally)
- [ ] `/reload` cleanly with this branch installed
- [ ] Minimap button still renders with the gear-ring border
- [ ] Item tooltips on TodoPage / DealFinder / Research still resolve via `SetHyperlink` (`ItemKeyToItemString` shim)
- [ ] Item-link paste in Generator wizard still parses bonus IDs / modifier-9 ilvl correctly (`ParseItemLink` shim)
- [ ] Quality-colored item names render correctly in TodoPage / Generator / DealFinder
- [ ] Gold values in TodoPage group headers + Next Steps render correctly

## Related

- FQ#143 (parent issue with full Phase A/B/C adoption map)
- Cogworks Items.lua + Text.lua (canonical implementations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
