### PR TITLE
refactor(FQ-143): Phase A2 — quiet 23 confirmation prints to cw:Toast

### DIFF
--- a/Sync.lua
+++ b/Sync.lua
@@ -1066,7 +1066,7 @@ function Sync:AcceptPair(senderID)
     local myBNetID = select(2, BNGetInfo())
     self:Enqueue(OP_PACK .. SEP .. myUUID .. SEP .. tostring(myBNetID or 0), replyTarget, PRIORITY[OP_PACK], replyTransport)
 
-    ns:Print(ns.COLORS.GREEN .. "Linked to " .. label .. "|r")
+    ns.cw:Toast({ severity = "success", text = "Linked to " .. label })
     self:StartHeartbeat()
     self:NotifyPartnerStateChanged()
 
@@ -1171,7 +1171,7 @@ function Sync:OnPairAck(payload, senderID)
     missedPings[remoteUUID] = 0
     ns.db.sync.partners[remoteUUID].lastSeen = time()
 
-    ns:Print(ns.COLORS.GREEN .. "Linked to " .. label .. "|r")
+    ns.cw:Toast({ severity = "success", text = "Linked to " .. label })
     self:StartHeartbeat()
     self:NotifyPartnerStateChanged()
 
@@ -1218,7 +1218,7 @@ function Sync:Unlink(accountUUID)
         self:SendRaw(OP_UNLK, target, transport)
     end
 
-    ns:Print("Unlinked from " .. (partner.label or "account"))
+    ns.cw:Toast({ severity = "info", text = "Unlinked from " .. (partner.label or "account") })
 
     -- Remove characters owned by this account
     for charKey, charData in pairs(ns.db.characters) do

--- a/Tracker.lua
+++ b/Tracker.lua
@@ -135,9 +135,9 @@ local function CheckForPosts()
         end
         local taskQty = p.item.quantity or 1
         if p.count < taskQty then
-            ns:Print(ns.COLORS.GREEN .. "Posted:|r " .. p.item.name .. " (x" .. p.count .. " of " .. taskQty .. ")")
+            ns.cw:Toast({ severity = "success", text = "Posted: " .. p.item.name .. " (x" .. p.count .. " of " .. taskQty .. ")" })
         else
-            ns:Print(ns.COLORS.GREEN .. "Posted:|r " .. p.item.name .. " (x" .. p.count .. ")")
+            ns.cw:Toast({ severity = "success", text = "Posted: " .. p.item.name .. " (x" .. p.count .. ")" })
         end
         -- Pass the snapshotted bag-item key so log entries preserve bonus
         -- IDs / modifiers even for posts done via TSM / Blizz UI (FQ-130).
@@ -454,7 +454,7 @@ function Tracker:ShowBankOpsPopup()
             end
             ns.BankQueue:ProcessSync(pullOps, "Pulling from bank...", function(successNames, errorCount, failedNames)
                 if #successNames > 0 then
-                    ns:Print("Pulled: " .. table.concat(successNames, ", "))
+                    ns.cw:Toast({ severity = "success", text = "Pulled: " .. table.concat(successNames, ", ") })
                 end
                 if errorCount > 0 then
                     local detail = (failedNames and #failedNames > 0)

--- a/TrackerBank.lua
+++ b/TrackerBank.lua
@@ -626,8 +626,8 @@ function Tracker:AutoDepositGold()
     local ok2, err = pcall(C_Bank.DepositMoney, Enum.BankType.Account, excessCopper)
     if ok2 then
         local keptGold = math.floor(keepCopper / 10000)
-        ns:Print(ns.COLORS.GREEN .. "Deposited " .. ns:FormatGold(excessCopper) .. "|r to warbank" ..
-            " (kept " .. keptGold .. "g for fees + buffer)")
+        ns.cw:Toast({ severity = "success", text = "Deposited " .. ns:FormatGold(excessCopper)
+            .. " to warbank (kept " .. keptGold .. "g for fees + buffer)" })
         return excessCopper
     else
         ns:PrintDebug("Failed to deposit gold: " .. tostring(err))
@@ -817,11 +817,11 @@ function Tracker:AutoDepositToWarbank(onComplete)
         local deferredCount = deferredNames and #deferredNames or 0
         if #successNames > 0 then
             if errorCount == 0 and deferredCount == 0 then
-                ns:Print(ns.COLORS.CYAN .. "Deposited " .. #successNames ..
-                    " item(s) to warbank:|r " .. table.concat(successNames, ", "))
+                ns.cw:Toast({ severity = "success", text = "Deposited " .. #successNames
+                    .. " item(s) to warbank: " .. table.concat(successNames, ", ") })
             else
-                ns:Print(ns.COLORS.CYAN .. "Deposited " .. #successNames ..
-                    " of " .. #ops .. " item(s) to warbank:|r " .. table.concat(successNames, ", "))
+                ns.cw:Toast({ severity = "success", text = "Deposited " .. #successNames
+                    .. " of " .. #ops .. " item(s) to warbank: " .. table.concat(successNames, ", ") })
             end
         end
         if errorCount > 0 then
@@ -1011,9 +1011,8 @@ function Tracker:AutoDepositExtraItems(onComplete)
     ns.BankQueue:Process(ops, "Depositing extras...", function(successNames, errorCount, deferredNames)
         local deferredCount = deferredNames and #deferredNames or 0
         if #successNames > 0 then
-            ns:Print(ns.COLORS.CYAN .. "Deposited " .. #successNames ..
-                " extra item(s) to warbank/bank:|r " ..
-                table.concat(successNames, ", "))
+            ns.cw:Toast({ severity = "success", text = "Deposited " .. #successNames
+                .. " extra item(s) to warbank/bank: " .. table.concat(successNames, ", ") })
         end
         if errorCount > 0 then
             ns:Print(ns.COLORS.YELLOW .. errorCount ..
@@ -1166,9 +1165,8 @@ function Tracker:AutoDepositReagents(onComplete)
     ns.BankQueue:Process(ops, "Depositing reagents...", function(successNames, errorCount, deferredNames)
         local deferredCount = deferredNames and #deferredNames or 0
         if #successNames > 0 then
-            ns:Print(ns.COLORS.CYAN .. "Deposited " .. #successNames ..
-                " reagent(s) to warbank/bank:|r " ..
-                table.concat(successNames, ", "))
+            ns.cw:Toast({ severity = "success", text = "Deposited " .. #successNames
+                .. " reagent(s) to warbank/bank: " .. table.concat(successNames, ", ") })
         end
         if errorCount > 0 then
             ns:Print(ns.COLORS.YELLOW .. errorCount ..

--- a/UI/GeneratorPage.lua
+++ b/UI/GeneratorPage.lua
@@ -952,7 +952,7 @@ function UI:RefreshGeneratorPage(pending)
                         for _, r in ipairs(s2.previewRows) do r:Hide() end
                         s2._lastLen = 0
                         local function Finish(added)
-                            ns:Print("Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged).")
+                            ns.cw:Toast({ severity = "success", text = "Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged)." })
                             s2.statusLabel:SetText(ns.COLORS.GREEN .. added .. " deals imported!|r")
                             -- Auto-advance to step 3 (generate) after auto-import
                             SaveWizardState(UI._wizardTrack, 3)
@@ -2187,12 +2187,12 @@ function UI:RefreshGeneratorPage(pending)
                         if total >= (ns.Import.LARGE_THRESHOLD or 500) then
                             ns:Print(ns.COLORS.YELLOW .. "Importing " .. total .. " deals (large paste, please wait)...|r")
                             ns.Import:SaveChunked(data, nil, ns.Import.CHUNK_SIZE, nil, function(added)
-                                ns:Print("Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged).")
+                                ns.cw:Toast({ severity = "success", text = "Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged)." })
                                 if UI.Refresh then UI:Refresh() end
                             end)
                         else
                             local added = ns.Import:Save(data)
-                            ns:Print("Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged).")
+                            ns.cw:Toast({ severity = "success", text = "Imported " .. added .. " new deals (" .. total .. " parsed, duplicates merged)." })
                         end
                     end
                 end
@@ -3251,10 +3251,10 @@ function UI:RefreshGeneratorPage(pending)
                 local count = UI._generatorPreview.items and #UI._generatorPreview.items or 0
                 if currentList2 then
                     ns.TodoList:CommitList(UI._generatorPreview, "upcoming")
-                    ns:Print(ns.COLORS.GREEN .. "Queued \"" .. listName .. "\" with " .. count .. " tasks.|r")
+                    ns.cw:Toast({ severity = "success", text = "Queued \"" .. listName .. "\" with " .. count .. " tasks." })
                 else
                     ns.TodoList:CommitList(UI._generatorPreview, "replace")
-                    ns:Print(ns.COLORS.GREEN .. "Saved \"" .. listName .. "\" with " .. count .. " tasks.|r")
+                    ns.cw:Toast({ severity = "success", text = "Saved \"" .. listName .. "\" with " .. count .. " tasks." })
                 end
                 UI._generatorPreview = nil
                 gf.nameBox._initialized = false
@@ -4429,8 +4429,8 @@ function UI:RefreshGeneratorPage(pending)
                         ns.TodoList:CommitList(previewSource.sell, "upcoming")
                     end
 
-                    ns:Print(ns.COLORS.GREEN .. "Saved \"" .. buyName .. "\" (" ..
-                        buyCount .. " buy) + \"" .. sellName .. "\" (" .. sellCount .. " sell)|r")
+                    ns.cw:Toast({ severity = "success", text = "Saved \"" .. buyName .. "\" ("
+                        .. buyCount .. " buy) + \"" .. sellName .. "\" (" .. sellCount .. " sell)" })
                 elseif previewSource and previewSource.items then
                     local listName = gf.nameBox:GetText():match("^%s*(.-)%s*$")
                     if not listName or listName == "" then
@@ -4441,10 +4441,10 @@ function UI:RefreshGeneratorPage(pending)
                     local currentList2 = ns.TodoList:GetCurrentList()
                     if currentList2 then
                         ns.TodoList:CommitList(previewSource, "upcoming")
-                        ns:Print(ns.COLORS.GREEN .. "Queued \"" .. listName .. "\" with " .. count .. " tasks.|r")
+                        ns.cw:Toast({ severity = "success", text = "Queued \"" .. listName .. "\" with " .. count .. " tasks." })
                     else
                         ns.TodoList:CommitList(previewSource, "replace")
-                        ns:Print(ns.COLORS.GREEN .. "Saved \"" .. listName .. "\" with " .. count .. " tasks.|r")
+                        ns.cw:Toast({ severity = "success", text = "Saved \"" .. listName .. "\" with " .. count .. " tasks." })
                     end
                 end
 

--- a/UI/InventoryPage.lua
+++ b/UI/InventoryPage.lua
@@ -287,9 +287,9 @@ function UI:RefreshInventoryPage()
                         quantity = rowData._quantity or 1,
                     }})
                     if added > 0 then
-                        ns:Print(ns.COLORS.GREEN .. "Added to queue:|r " .. (rowData._itemName or rowData.name))
+                        ns.cw:Toast({ severity = "success", text = "Added to queue: " .. (rowData._itemName or rowData.name) })
                     else
-                        ns:Print(ns.COLORS.GRAY .. "Already in queue:|r " .. (rowData._itemName or rowData.name))
+                        ns.cw:Toast({ severity = "info", text = "Already in queue: " .. (rowData._itemName or rowData.name) })
                     end
                 else
                     ns:AddDoNotTrack(rowData._itemID, rowData._itemName)
@@ -303,7 +303,7 @@ function UI:RefreshInventoryPage()
                     for importKey, qItem in pairs(ns.db.imports.fpScanner or {}) do
                         if ns:ItemsMatch(qItem.itemKey, qItem.name, {itemKey = rowData._itemKey, itemID = tostring(rowData._itemID), name = rowData._itemName}) then
                             ns:ImportRemove("fpScanner", importKey)
-                            ns:Print(ns.COLORS.RED .. "Removed from queue:|r " .. (rowData._itemName or rowData.name))
+                            ns.cw:Toast({ severity = "info", text = "Removed from queue: " .. (rowData._itemName or rowData.name) })
                             break
                         end
                     end

--- a/UI/MiniView.lua
+++ b/UI/MiniView.lua
@@ -762,7 +762,7 @@ function UI:RefreshMini()
                             ns:Print(ns.COLORS.ORANGE .. "Skipped:|r " .. capturedTask.name)
                         else
                             ns.TodoList:MoveTaskToLog(capturedTask._taskIdx)
-                            ns:Print("Posted: " .. capturedTask.name .. " -> moved to log")
+                            ns.cw:Toast({ severity = "success", text = "Posted: " .. capturedTask.name .. " — moved to log" })
                         end
                     end
                     UI:RefreshMini()

--- a/UI/TodoPage.lua
+++ b/UI/TodoPage.lua
@@ -1199,7 +1199,7 @@ function UI:RefreshTodoPage()
                         ns:Print(ns.COLORS.ORANGE .. "Skipped:|r " .. rowData.name)
                     else
                         ns.TodoList:MoveTaskToLog(rowData._taskIndex)
-                        ns:Print("Posted: " .. rowData.name .. " -> moved to log")
+                        ns.cw:Toast({ severity = "success", text = "Posted: " .. rowData.name .. " — moved to log" })
                     end
                     actionRefresh()
                 end


### PR DESCRIPTION
Third of three Phase A2 PRs under FQ-143 (Cogworks UI primitives adoption).

## Summary
23 success-style confirmation prints across 7 files convert from colored \`ns:Print\` to \`ns.cw:Toast\` so they surface in the top-right toast stack instead of cluttering chat. Severity (\"success\" / \"info\") replaces the WoW colour-code wrapping in the literals; loud-and-actionable prints (errors, blocked-by, must-act-now warnings, debug dumps) deliberately stay in chat.

## Sites converted

| File | Count | Messages |
|---|---|---|
| \`Tracker.lua\` | 3 | Posted (partial qty / full qty), Pulled |
| \`Sync.lua\` | 3 | Linked (BNet + whisper paths), Unlinked |
| \`TrackerBank.lua\` | 5 | Deposited gold, items (full / partial), extras, reagents |
| \`UI/GeneratorPage.lua\` | 8 | Imported deals (3 paths), Queued / Saved (3 paths), Saved buy+sell pair |
| \`UI/InventoryPage.lua\` | 2 | Added / Removed from queue |
| \`UI/MiniView.lua\` | 1 | Posted -> log (right-click ledger move) |
| \`UI/TodoPage.lua\` | 1 | Posted -> log (right-click ledger move) |

## Why these specifically
Each is a clean per-action confirmation that the player already triggered and doesn't need to re-read in chat. The toast tint conveys severity at a glance (success-green or info-blue), and the auto-dismiss keeps the chat panel clean for stuff that actually matters.

The ~225 surviving \`ns:Print\` call sites stay as chat: errors, debug dumps, multi-line state exports, blocked-by warnings, anything the player needs to act on.

## Test plan
- [ ] Post a partial-qty stack from the to-do list — toast shows \"Posted: <name> (xN of M)\"
- [ ] Post a full-qty stack — toast shows \"Posted: <name> (xN)\"
- [ ] Pull from bank popup — toast shows \"Pulled: <names>\"
- [ ] Trigger auto-deposit gold to warbank — toast shows \"Deposited Xg to warbank...\"
- [ ] Run a deposit-items batch — toast shows \"Deposited N item(s) to warbank: ...\"
- [ ] Run an extras-deposit / reagent-deposit batch — toasts appear (separate flows)
- [ ] Wizard import (auto-import) — toast shows \"Imported N new deals...\"
- [ ] Wizard import (large paste, chunked) — toast appears at finish
- [ ] Save a generated to-do list — \"Queued / Saved <name> with N tasks\"
- [ ] Save a buy+sell pair — combined toast
- [ ] Right-click an inventory row to add/remove from queue — toast appears
- [ ] Right-click a to-do row to mark posted — \"Posted: <name> — moved to log\"
- [ ] Same flow from MiniView right-click — same toast
- [ ] Link / unlink an account — toasts (\"Linked to X\", \"Unlinked from X\")
- [ ] Toasts stack vertically when several fire close together (e.g., post then move-to-log)
- [ ] Errors and warnings still show in chat (e.g., \"N pull(s) failed\", AH-error notices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)