### PR TITLE
fix(FQ-173): exclude Warbound gear from auto-generated AH lists

### DIFF
--- a/ItemBindings.lua
+++ b/ItemBindings.lua
@@ -1,0 +1,81 @@
+-- ItemBindings.lua
+-- Detect Warbound / Warbound-until-Equipped status by tooltip scan.
+-- C_Item.GetItemInfo's bindType column reports the *intrinsic* binding
+-- (BoP/BoE/BoU/BoA/etc.) but doesn't distinguish "Warbound until Equipped"
+-- from a regular BoE — both report bindType=2. Syndicator's slot.isBound
+-- only flips true once an item is fully soulbound to a character, so
+-- warbound gear sitting in bags or warbank slips through downstream
+-- "tradeable" filters (FQ-173).
+--
+-- Mirrors Syndicator's tooltip-scan approach (Search/CheckItem.lua) by
+-- reading the localized account-bound tooltip lines. Cache key is the full
+-- itemKey since some bonus-ID variants (crafted reagent quality) flip the
+-- binding even when the base itemID matches.
+
+local addonName, ns = ...
+
+local Bindings = {}
+ns.ItemBindings = Bindings
+
+local cache = {}
+
+local WARBOUND_LINES = {}
+do
+    local candidates = {
+        ITEM_ACCOUNTBOUND,
+        ITEM_ACCOUNTBOUND_UNTIL_EQUIP,
+        ITEM_BIND_TO_ACCOUNT,
+        ITEM_BIND_TO_ACCOUNT_UNTIL_EQUIP,
+        ITEM_BIND_TO_BNETACCOUNT,
+        ITEM_BNETACCOUNTBOUND,
+        ITEM_BNETACCOUNTBOUND_UNTIL_EQUIP,
+    }
+    for _, line in ipairs(candidates) do
+        if line and line ~= "" then
+            WARBOUND_LINES[line] = true
+        end
+    end
+end
+
+local scanTooltip
+local function GetScanTooltip()
+    if not scanTooltip then
+        scanTooltip = CreateFrame("GameTooltip", "FlipQueueBindingScanTooltip",
+            UIParent, "GameTooltipTemplate")
+        scanTooltip:SetOwner(UIParent, "ANCHOR_NONE")
+    end
+    return scanTooltip
+end
+
+-- Returns false (and does NOT cache) when item data isn't loaded yet, so a
+-- later scan after GET_ITEM_INFO_RECEIVED can re-evaluate.
+function Bindings:IsWarbound(itemKey, itemLink)
+    if not itemKey then return false end
+    local cached = cache[itemKey]
+    if cached ~= nil then return cached end
+    if not itemLink or itemLink == "" then return false end
+
+    local tt = GetScanTooltip()
+    tt:ClearLines()
+    local ok = pcall(tt.SetHyperlink, tt, itemLink)
+    if not ok then return false end
+
+    local n = tt:NumLines()
+    if n == 0 then return false end
+
+    for i = 1, n do
+        local fontstring = _G["FlipQueueBindingScanTooltipTextLeft" .. i]
+        local text = fontstring and fontstring:GetText()
+        if text and WARBOUND_LINES[text] then
+            cache[itemKey] = true
+            return true
+        end
+    end
+
+    cache[itemKey] = false
+    return false
+end
+
+function Bindings:ClearCache()
+    wipe(cache)
+end

--- a/Scanner.lua
+++ b/Scanner.lua
@@ -87,7 +87,8 @@ end
 -- Shared helper: take a Syndicator container-slot list and fold each slot
 -- into the caller's items table, tagging quantities against `location`.
 -- The `items` table has the pre-6a shape: `items[key] = { itemID, bonusIDs,
--- modifiers, quantity, icon, ilvl, bindType, isBound, locations = {...} }`.
+-- modifiers, quantity, icon, ilvl, bindType, isBound, isWarbound,
+-- locations = {...} }`.
 -- Battle pets are handled via link parsing (Syndicator includes the full
 -- caged-pet hyperlink).
 local function FoldContainerSlots(slots, items, location)
@@ -131,18 +132,25 @@ local function FoldContainerSlots(slots, items, location)
                         end
                     end
                     entry = {
-                        itemID    = itemID,
-                        name      = itemName or "Unknown",
-                        bonusIDs  = bonusIDs or "",
-                        modifiers = modifiers or "",
-                        quantity  = 0,
-                        icon      = slot.iconTexture,
-                        ilvl      = ilvl,
-                        locations = {},
-                        bindType  = bindType,
-                        isBound   = slot.isBound and true or false,
+                        itemID     = itemID,
+                        name       = itemName or "Unknown",
+                        bonusIDs   = bonusIDs or "",
+                        modifiers  = modifiers or "",
+                        quantity   = 0,
+                        icon       = slot.iconTexture,
+                        ilvl       = ilvl,
+                        locations  = {},
+                        bindType   = bindType,
+                        isBound    = slot.isBound and true or false,
+                        isWarbound = false,
                     }
                     items[key] = entry
+                end
+                -- Refresh isWarbound on every fold so a tooltip scan that
+                -- was deferred (item data not yet loaded) gets resolved on
+                -- a later pass once GET_ITEM_INFO_RECEIVED fires.
+                if not entry.isWarbound and ns.ItemBindings then
+                    entry.isWarbound = ns.ItemBindings:IsWarbound(key, link)
                 end
                 local count = slot.itemCount or 1
                 entry.quantity = entry.quantity + count

--- a/TodoGenerator.lua
+++ b/TodoGenerator.lua
@@ -86,9 +86,13 @@ function TodoList:BuildItemPool()
                 local numID = tonumber(itemData.itemID)
                 local isDNT = numID and ns:IsDoNotTrack(numID)
                 -- Exclude soulbound/untradeable: isBound BoE/BoU = soulbound,
-                -- BoP (1), Quest (4), BtA (7), BtW (8) can never be sold on AH
+                -- BoP (1), Quest (4), BtA (7), BtW (8) can never be sold on AH.
+                -- isWarbound covers Warbound / Warbound-until-Equipped gear
+                -- (FQ-173) — bindType reports BoE for WuE so a tooltip-scan
+                -- pass at scan time is the only way to flag it.
                 local bt = itemData.bindType
                 local tradeable = not itemData.isBound
+                    and not itemData.isWarbound
                     and (not bt or (bt ~= 1 and bt ~= 4 and bt ~= 7 and bt ~= 8))
 
                 if not isDNT and tradeable then
@@ -111,6 +115,7 @@ function TodoList:BuildItemPool()
             local isDNT = numID and ns:IsDoNotTrack(numID)
             local bt = itemData.bindType
             local tradeable = not itemData.isBound
+                and not itemData.isWarbound
                 and (not bt or (bt ~= 1 and bt ~= 4 and bt ~= 7 and bt ~= 8))
             if not isDNT and tradeable and (itemData.quantity or 0) > 0 then
                 AddToPool(itemKey, itemData, "Warbank", "warbank", itemData.quantity)

--- a/flipqueue.toc
+++ b/flipqueue.toc
@@ -25,6 +25,7 @@ DB.lua
 TSM.lua
 TSMRealms.lua
 ItemLookup.lua
+ItemBindings.lua
 Scanner.lua
 Import.lua
 Export.lua


### PR DESCRIPTION
## Summary

- Adds `ItemBindings.lua` — tooltip-scans for the localized account-bound strings (`ITEM_ACCOUNTBOUND`, `ITEM_ACCOUNTBOUND_UNTIL_EQUIP`, BNet variants) the same way Syndicator does in `Search/CheckItem.lua`. Cache key is the full `itemKey` since bonus-ID variants can flip the binding (crafted reagent quality).
- `Scanner.lua` stamps an `isWarbound` flag on every entry at fold time. Refresh-on-fold so a tooltip scan that was deferred (item data not loaded yet) gets resolved on a later pass once `GET_ITEM_INFO_RECEIVED` fires.
- `TodoGenerator.lua` tradeable filter rejects on `isWarbound` in both the inventory and warbank passes.

## Why this needs the tooltip-scan path

`C_Item.GetItemInfo` reports `bindType = 2` (BoE) for "Warbound until Equipped" — indistinguishable from a regular tradeable BoE. Syndicator's `slot.isBound` only flips true once an item is fully soulbound to a character, so a warbound stack sitting in bags or warbank slipped through. `C_Item.IsBoundToAccountUntilEquip` would work but needs a live `ItemLocation` — Syndicator's cached slot data drops bag/slot indices, so the API can't help with projected alt inventory (which is most of the deal pool).

## Behavior on existing data

Existing `ns.db.characters[X].inventory.items` entries from before this change have no `isWarbound` field — the filter sees `nil`, treats it as not-warbound. Stale entries refresh on the next bag/bank/warbank update (next time the player opens those containers, or on next alt login). No migration needed; the auto-gen list improves incrementally.

## Test plan

- [ ] Player on a character with Warbound-until-Equipped gear in bags runs To-Do Generator → Deal Finder; warbound gear must NOT appear in the generated list
- [ ] Same with warbound gear in warbank
- [ ] Regular BoE gear still appears (filter doesn't false-positive)
- [ ] `/fq` window opens with no Lua errors at PLAYER_LOGIN
- [ ] Bag-update churn doesn't visibly stutter (tooltip cache should make repeat calls free)

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)