### PR TITLE
chore(FQ-140): remove redundant 'Refresh Auctionator Buy List' MiniView button

### DIFF
--- a/UI/MiniView.lua
+++ b/UI/MiniView.lua
@@ -774,33 +774,6 @@ function UI:RefreshMini()
         end
     end
 
-    -- Auctionator shopping list button (when buy tasks exist and Auctionator is loaded)
-    if buyCount and buyCount > 0 and type(Auctionator) == "table"
-            and type(Auctionator.API) == "table" and type(Auctionator.API.v1) == "table" then
-        rowIndex = rowIndex + 1
-        local auctRow = GetOrCreateMiniRow(rowIndex)
-        auctRow.icon:SetTexture("Interface\\Icons\\INV_Misc_Spyglass_03")
-        auctRow.text:SetText(ns.COLORS.YELLOW .. "Refresh Auctionator Buy List" .. ns.COLORS.RESET)
-        auctRow.tooltipItemID = nil; auctRow.tooltipItemKey = nil
-        auctRow.tooltipItemName = "Refresh Shopping List"
-        auctRow.tooltipExtra = "Rebuild the FlipQueue buy list now (" .. buyCount .. " buy items). Lists also refresh automatically when you open the AH or buy something."
-        auctRow:SetScript("OnMouseDown", function()
-            if not ns.BuyListSync then
-                ns:Print(ns.COLORS.RED .. "BuyListSync not loaded.|r")
-                return
-            end
-            local total, created, _, err = ns.BuyListSync:Rebuild(true)
-            if err then
-                ns:Print(ns.COLORS.RED .. "Buy list error: " .. err .. "|r")
-            elseif total then
-                ns:Print(ns.COLORS.GREEN .. "Refreshed " .. (created or 0) ..
-                    " list(s) with " .. total .. " item(s).|r")
-            end
-            UI:RefreshMini()
-        end)
-        auctRow:Show()
-    end
-
     -- Current character tasks (Check Mail, Expiring)
     local charTasks = UI.BuildCurrentCharTasks and UI.BuildCurrentCharTasks() or {}
     if #charTasks > 0 then


### PR DESCRIPTION
## Summary

Removes the `Refresh Auctionator Buy List` row from MiniView. `BuyListSync` already auto-rebuilds on:

- AH open
- Post
- Buy
- Auctionator-enable toggle (`UI/AuctionatorFrame.lua:189`)
- List deletion (`UI/AuctionatorFrame.lua:257`)

…so the manual button was redundant. zpectre's report was that on busy realms the row gets pushed below the visible row count anyway, which made it look like the auto-refresh was broken. Cleanest fix is to remove the source of confusion rather than relocate.

If we ever want a manual escape hatch back, a `/fq` slash command is cheaper than UI real estate.

## Test plan

- [ ] MiniView shows current-character buy/sell rows correctly with Auctionator loaded
- [ ] No Lua errors on AH open or post events
- [ ] Auto-rebuild still fires on AH open (Auctionator buy list updates without manual action)

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)