### PR TITLE
refactor(FQ-143): Phase B — adopt cw:CreateDebugConsole

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -91,33 +91,24 @@ function ns:PrintError(msg)
     end
 end
 
--- Ring buffer of recent debug messages, exposed for the in-game debug
--- console (UI/DebugPopup.lua). Always populated regardless of whether
--- debugMessages is on, so the console can show the last N messages even
--- when the user just enabled debug mode.
-ns._debugLog = ns._debugLog or {}
-ns._debugLogMax = 500
+-- Debug log + chat-echo gate live in Cogworks (cw:DebugPrint, cw:SetDebugEnabled).
+-- ns:PrintDebug forwards through; ns:SetDebugEnabled keeps the persisted
+-- ns.db.settings.debugMessages flag and the cw runtime flag in sync so
+-- chat-echo gating matches the user's saved preference.
 
 function ns:PrintDebug(msg)
-    -- Push to the ring buffer regardless of the debugMessages setting so the
-    -- in-game debug console always has recent context. This side effect is
-    -- FlipQueue-specific and stays local — Cogworks doesn't own debug logs.
-    local ts = date("%H:%M:%S")
-    ns._debugLog[#ns._debugLog + 1] = ts .. "  " .. tostring(msg)
-    if #ns._debugLog > ns._debugLogMax then
-        table.remove(ns._debugLog, 1)
+    if ns.cw and ns.cw.DebugPrint then
+        ns.cw:DebugPrint("FlipQueue", tostring(msg))
     end
-    -- Notify the debug popup if it's open so it can append the new line live.
-    if ns.UI and ns.UI._OnDebugLogAppend then
-        ns.UI:_OnDebugLogAppend()
-    end
+end
 
-    if ns.db and ns.db.settings.debugMessages then
-        -- Debug prints stay on the local print() path even when Cogworks
-        -- is loaded — the "[debug]" suffix and gray coloring are custom
-        -- enough that routing through cw:Print would require a dedicated
-        -- Cogworks API. Not worth the API surface right now.
-        print(ns.COLORS.GRAY .. "FlipQueue [debug]:|r " .. msg)
+function ns:SetDebugEnabled(enabled)
+    enabled = enabled and true or false
+    if ns.db and ns.db.settings then
+        ns.db.settings.debugMessages = enabled
+    end
+    if ns.cw and ns.cw.SetDebugEnabled then
+        ns.cw:SetDebugEnabled("FlipQueue", enabled)
     end
 end
 

--- a/UI/DebugConsole.lua
+++ b/UI/DebugConsole.lua
@@ -1,26 +1,21 @@
 -- UI/DebugConsole.lua
--- In-game debug console: buttons to fire UI tests + live debug log view.
+-- Thin wrapper around Cogworks' debug toolkit. Registers FlipQueue's actions
+-- with cw:RegisterDebugAction and shows the cw:CreateDebugConsole frame keyed
+-- to "FlipQueue". The chrome, log ring, action grid, status row, and toggle
+-- button all live in the library — this file owns only FlipQueue-specific
+-- action bodies and the slash-command entry points.
+--
 -- Open with /fq debug or /fq debug console.
 local addonName, ns = ...
 
 local UI = ns.UI
-local console = nil
+local cw = ns.cw
 
-local CONSOLE_WIDTH  = 460
-local CONSOLE_HEIGHT = 520
-local LOG_LINE_HEIGHT = 12
+local consoleFrame  -- created lazily on first show
 
 --------------------------
 -- Helpers
 --------------------------
-
-local function MakeButton(parent, label, onClick)
-    local b = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate")
-    b:SetSize(150, 22)
-    b:SetText(label)
-    b:SetScript("OnClick", onClick)
-    return b
-end
 
 -- Build a fake op array for the bank popup. Each op needs name, icon, quantity.
 local function FakeOps(prefix, count)
@@ -37,15 +32,16 @@ local function FakeOps(prefix, count)
 end
 
 --------------------------
--- Debug Action Registry
+-- Action Registry
 --------------------------
 
--- Each action: { label, run = function() ... end }
--- Add new entries here to surface new debug buttons in the console.
-local actions = {
-    {
-        label = "Bank popup ×60",
-        run = function()
+-- Register FlipQueue's debug actions with Cogworks. The library's debug
+-- console picks them up automatically and renders them in the Actions tab.
+local function RegisterFlipQueueActions()
+    if not cw or not cw.RegisterDebugAction then return end
+
+    local actions = {
+        { "Bank popup ×60", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
                 UI:ShowBankPopup({
@@ -54,11 +50,8 @@ local actions = {
                     extras   = FakeOps("Extra",   20),
                 }, function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Bank popup ×6",
-        run = function()
+        end },
+        { "Bank popup ×6", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
                 UI:ShowBankPopup({
@@ -67,44 +60,29 @@ local actions = {
                     extras   = FakeOps("Extra",   2),
                 }, function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Bank popup pulls only",
-        run = function()
+        end },
+        { "Bank popup pulls only", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
-                UI:ShowBankPopup({
-                    pulls = FakeOps("Pull", 30),
-                }, function() ns:Print("Debug popup execute (no-op).") end)
+                UI:ShowBankPopup({ pulls = FakeOps("Pull", 30) },
+                    function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Bank popup deposits only",
-        run = function()
+        end },
+        { "Bank popup deposits only", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
-                UI:ShowBankPopup({
-                    deposits = FakeOps("Deposit", 30),
-                }, function() ns:Print("Debug popup execute (no-op).") end)
+                UI:ShowBankPopup({ deposits = FakeOps("Deposit", 30) },
+                    function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Bank popup extras only",
-        run = function()
+        end },
+        { "Bank popup extras only", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
-                UI:ShowBankPopup({
-                    extras = FakeOps("Extra", 30),
-                }, function() ns:Print("Debug popup execute (no-op).") end)
+                UI:ShowBankPopup({ extras = FakeOps("Extra", 30) },
+                    function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Bank popup gold only",
-        run = function()
+        end },
+        { "Bank popup gold only", function()
             if UI.HideBankPopup then UI:HideBankPopup() end
             if UI.ShowBankPopup then
                 UI:ShowBankPopup({
@@ -112,35 +90,16 @@ local actions = {
                     goldDeposit  = 9876543,
                 }, function() ns:Print("Debug popup execute (no-op).") end)
             end
-        end,
-    },
-    {
-        label = "Toggle debug mode",
-        run = function()
-            if not ns.db then return end
-            ns.db.settings.debugMessages = not ns.db.settings.debugMessages
-            ns:Print("Debug messages: " .. (ns.db.settings.debugMessages
-                and ns.COLORS.GREEN .. "ON" or ns.COLORS.RED .. "OFF") .. "|r")
-            -- Refresh the status indicator if the console is open.
-            if UI._RefreshDebugStatus then UI:_RefreshDebugStatus() end
-        end,
-    },
-    {
-        label = "Export FQ state",
-        run = function()
-            -- Reuse the existing /fq state pipeline so the format stays
-            -- in sync with the slash command (one source of truth).
+        end },
+        { "Export FQ state", function()
+            -- Reuse the existing /fq state pipeline so the format stays in
+            -- sync with the slash command (one source of truth).
             if SlashCmdList and SlashCmdList.FLIPQUEUE then
                 SlashCmdList.FLIPQUEUE("state")
             end
-        end,
-    },
-    {
-        label = "Copy debug log",
-        run = function()
-            local log = ns._debugLog or {}
-            -- Prefix with version + capture timestamp so bug-report pastes
-            -- self-identify which build and when the log was captured.
+        end },
+        { "Copy debug log", function()
+            local log = cw and cw.GetDebugEntries and cw:GetDebugEntries("FlipQueue") or {}
             local versionLine
             if UI and UI.GetVersionLine then
                 versionLine = UI:GetVersionLine()
@@ -150,254 +109,97 @@ local actions = {
             local header = string.format(
                 "=== %s — debug log ===\ncaptured: %s\n",
                 versionLine, date("%Y-%m-%d %H:%M:%S"))
-
-            local body
-            if #log == 0 then
-                body = "(debug log empty)"
-            else
-                body = table.concat(log, "\n")
-            end
+            local body = (#log == 0) and "(debug log empty)" or table.concat(log, "\n")
             local text = header .. "\n" .. body
             if UI.ShowExportPopup then
                 UI:ShowExportPopup(text, #log .. " line(s) — Ctrl+A, Ctrl+C to copy")
             end
-        end,
-    },
-    {
-        label = "Emit test debug log",
-        run = function()
+        end },
+        { "Emit test debug log", function()
             for i = 1, 10 do
                 ns:PrintDebug("Test debug message #" .. i)
             end
-        end,
-    },
-    {
-        label = "Clear debug log",
-        run = function()
-            wipe(ns._debugLog or {})
-            if UI._OnDebugLogAppend then UI:_OnDebugLogAppend() end
+        end },
+        { "Clear debug log", function()
+            if cw and cw.ClearDebugLog then cw:ClearDebugLog("FlipQueue") end
             ns:Print("Debug log cleared.")
-        end,
-    },
-}
+        end },
+    }
+
+    for _, entry in ipairs(actions) do
+        cw:RegisterDebugAction("FlipQueue", entry[1], entry[2])
+    end
+end
 
 -- Public registration so other modules can add their own debug actions
--- without editing this file.
+-- without editing this file. Backward-compatible with the pre-Cogworks API.
 function UI:RegisterDebugAction(label, fn)
     if type(label) ~= "string" or type(fn) ~= "function" then return end
-    table.insert(actions, { label = label, run = fn })
-    if console and console:IsShown() then
-        UI:_RebuildDebugButtons()
+    if cw and cw.RegisterDebugAction then
+        cw:RegisterDebugAction("FlipQueue", label, fn)
     end
 end
 
 --------------------------
--- Frame Construction
+-- Console Lifecycle
 --------------------------
 
-local function GetConsole()
-    if console then return console end
+local function EnsureConsole()
+    if consoleFrame then return consoleFrame end
+    if not cw or not cw.CreateDebugConsole then return nil end
 
-    local f = CreateFrame("Frame", "FlipQueueDebugConsole", UIParent, "BackdropTemplate")
-    f:SetSize(CONSOLE_WIDTH, CONSOLE_HEIGHT)
-    -- Default to top-left so the console doesn't overlap the typical
-    -- mini-view position (top-right). The frame is movable so the user
-    -- can drag it elsewhere.
-    f:SetPoint("TOPLEFT", UIParent, "TOPLEFT", 40, -120)
-    f:SetFrameStrata("DIALOG")
-    f:SetClampedToScreen(true)
-    f:SetMovable(true)
-    f:EnableMouse(true)
-    f:RegisterForDrag("LeftButton")
-    f:SetScript("OnDragStart", f.StartMoving)
-    f:SetScript("OnDragStop", function(self) self:StopMovingOrSizing() end)
-    f:SetBackdrop({
-        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
-        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
-        edgeSize = 16,
-        insets = { left = 4, right = 4, top = 4, bottom = 4 },
+    -- Push the persisted debug-echo flag into Cogworks before the console
+    -- renders its status row, so the "ON / OFF" label matches the saved
+    -- preference on first open.
+    if ns.db and ns.db.settings then
+        ns:SetDebugEnabled(ns.db.settings.debugMessages and true or false)
+    end
+
+    -- Persist console geometry under ns.db.debugConsole.
+    if ns.db then
+        ns.db.debugConsole = ns.db.debugConsole or {}
+    end
+
+    consoleFrame = cw:CreateDebugConsole({
+        cog       = "FlipQueue",
+        width     = 460,
+        height    = 520,
+        savedvars = ns.db and ns.db.debugConsole or nil,
     })
-    f:SetBackdropColor(0.05, 0.05, 0.08, 0.97)
-    f:SetBackdropBorderColor(0.4, 0.4, 0.5, 1)
 
-    -- Title bar
-    local bar = CreateFrame("Frame", nil, f)
-    bar:SetHeight(24)
-    bar:SetPoint("TOPLEFT", f, "TOPLEFT", 4, -4)
-    bar:SetPoint("TOPRIGHT", f, "TOPRIGHT", -4, -4)
-    local barBg = bar:CreateTexture(nil, "BACKGROUND")
-    barBg:SetAllPoints()
-    barBg:SetColorTexture(0.12, 0.12, 0.18, 1)
-
-    f.title = bar:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    f.title:SetPoint("LEFT", bar, "LEFT", 8, 0)
-    -- #146: surface version in the title bar so testers grabbing a screenshot
-    -- of the console window still capture which build they're running.
-    f.title:SetText(ns.COLORS.YELLOW .. "FlipQueue|r Debug Console — v" .. (ns.VERSION or "dev"))
-
-    local closeBtn = CreateFrame("Button", nil, bar)
-    closeBtn:SetSize(18, 18)
-    closeBtn:SetPoint("RIGHT", bar, "RIGHT", -4, 0)
-    closeBtn:SetNormalTexture("Interface\\Buttons\\UI-StopButton")
-    closeBtn:SetHighlightTexture("Interface\\Buttons\\UI-StopButton")
-    closeBtn:GetHighlightTexture():SetAlpha(0.3)
-    closeBtn:SetScript("OnClick", function() f:Hide() end)
-
-    -- Status row: shows whether chat-output debug mode is on or off.
-    local statusRow = CreateFrame("Frame", nil, f)
-    statusRow:SetHeight(18)
-    statusRow:SetPoint("TOPLEFT", bar, "BOTTOMLEFT", 4, -4)
-    statusRow:SetPoint("TOPRIGHT", bar, "BOTTOMRIGHT", -4, -4)
-
-    f.statusFS = statusRow:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    f.statusFS:SetPoint("LEFT", statusRow, "LEFT", 4, 0)
-
-    -- Button area: grid of debug action buttons
-    local btnArea = CreateFrame("Frame", nil, f)
-    btnArea:SetPoint("TOPLEFT", statusRow, "BOTTOMLEFT", 0, -4)
-    btnArea:SetPoint("TOPRIGHT", statusRow, "BOTTOMRIGHT", 0, -4)
-    btnArea:SetHeight(180)
-    f.btnArea = btnArea
-
-    -- Log area (bottom): scrollable text view of recent debug messages
-    local logLabel = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
-    logLabel:SetPoint("TOPLEFT", btnArea, "BOTTOMLEFT", 4, -4)
-    logLabel:SetText(ns.COLORS.GRAY .. "Debug Log (live):|r")
-
-    local scroll = CreateFrame("ScrollFrame", nil, f, "UIPanelScrollFrameTemplate")
-    scroll:SetPoint("TOPLEFT", logLabel, "BOTTOMLEFT", 0, -4)
-    scroll:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -28, 12)
-
-    local logContent = CreateFrame("Frame", nil, scroll)
-    logContent:SetSize(1, 1)
-    scroll:SetScrollChild(logContent)
-    f.logScroll = scroll
-    f.logContent = logContent
-
-    f.logFS = logContent:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    f.logFS:SetPoint("TOPLEFT", logContent, "TOPLEFT", 4, -2)
-    f.logFS:SetPoint("TOPRIGHT", logContent, "TOPRIGHT", -4, -2)
-    f.logFS:SetJustifyH("LEFT")
-    f.logFS:SetJustifyV("TOP")
-    f.logFS:SetWordWrap(true)
-    f.logFS:SetSpacing(1)
-
-    -- ESC closes
-    f:SetScript("OnKeyDown", function(self, key)
-        if key == "ESCAPE" then
-            self:SetPropagateKeyboardInput(false)
-            self:Hide()
-        else
-            self:SetPropagateKeyboardInput(true)
-        end
-    end)
-
-    f:Hide()
-    console = f
-    return f
-end
-
---------------------------
--- Button Grid + Log Updater
---------------------------
-
-function UI:_RebuildDebugButtons()
-    if not console then return end
-    local area = console.btnArea
-    if not area._buttons then area._buttons = {} end
-    -- Hide existing buttons
-    for _, b in ipairs(area._buttons) do b:Hide() end
-
-    local cols = 2
-    local btnW, btnH = 215, 22
-    local padX, padY = 8, 6
-    for i, action in ipairs(actions) do
-        local b = area._buttons[i]
-        if not b then
-            b = MakeButton(area, action.label, action.run)
-            area._buttons[i] = b
-        else
-            b:SetText(action.label)
-            b:SetScript("OnClick", action.run)
-        end
-        b:SetSize(btnW, btnH)
-        local col = (i - 1) % cols
-        local row = math.floor((i - 1) / cols)
-        b:ClearAllPoints()
-        b:SetPoint("TOPLEFT", area, "TOPLEFT", col * (btnW + padX), -row * (btnH + padY))
-        b:Show()
+    -- Mirror cw's runtime toggle state back to ns.db so the next session
+    -- restores whatever the player last left it on. Hook OnHide so the
+    -- write happens before SaveVariables fires at logout.
+    if consoleFrame and consoleFrame.HookScript then
+        consoleFrame:HookScript("OnHide", function()
+            if ns.db and ns.db.settings and cw.IsDebugEnabled then
+                ns.db.settings.debugMessages = cw:IsDebugEnabled("FlipQueue") and true or false
+            end
+        end)
     end
 
-    -- Resize the button area to fit the actual rows so the log scroll
-    -- below has the right starting Y, regardless of how many actions
-    -- have been registered.
-    local rowCount = math.ceil(#actions / cols)
-    local neededHeight = math.max(1, rowCount * (btnH + padY) + 4)
-    area:SetHeight(neededHeight)
+    return consoleFrame
 end
-
-function UI:_RefreshDebugStatus()
-    if not console then return end
-    local on = ns.db and ns.db.settings.debugMessages
-    local label
-    if on then
-        label = "Debug Mode: " .. ns.COLORS.GREEN .. "ON|r"
-            .. ns.COLORS.GRAY .. "  (chat output enabled)|r"
-    else
-        label = "Debug Mode: " .. ns.COLORS.RED .. "OFF|r"
-            .. ns.COLORS.GRAY .. "  (chat output suppressed; log still captured)|r"
-    end
-    console.statusFS:SetText(label)
-end
-
-local function FormatLogText()
-    local log = ns._debugLog or {}
-    -- Show the last N lines that fit roughly in the window
-    local maxLines = 200
-    local startIdx = math.max(1, #log - maxLines + 1)
-    local lines = {}
-    for i = startIdx, #log do
-        lines[#lines + 1] = log[i]
-    end
-    return table.concat(lines, "\n")
-end
-
-function UI:_OnDebugLogAppend()
-    if not (console and console:IsShown()) then return end
-    console.logFS:SetText(FormatLogText())
-    -- Resize the scroll child to fit the text
-    local h = console.logFS:GetStringHeight() + 8
-    console.logContent:SetHeight(math.max(h, console.logScroll:GetHeight()))
-    console.logContent:SetWidth(console.logScroll:GetWidth())
-    -- Auto-scroll to bottom
-    local maxScroll = console.logScroll:GetVerticalScrollRange()
-    console.logScroll:SetVerticalScroll(maxScroll)
-end
-
---------------------------
--- Public API
---------------------------
 
 function UI:ShowDebugConsole()
-    local f = GetConsole()
-    UI:_RebuildDebugButtons()
-    UI:_RefreshDebugStatus()
-    UI:_OnDebugLogAppend()
-    f:Show()
-    -- Initial scroll-to-bottom on next frame so the layout is settled.
-    C_Timer.After(0, function()
-        if console and console:IsShown() then UI:_OnDebugLogAppend() end
-    end)
+    local f = EnsureConsole()
+    if f then f:Show() end
 end
 
 function UI:HideDebugConsole()
-    if console then console:Hide() end
+    if consoleFrame then consoleFrame:Hide() end
 end
 
 function UI:ToggleDebugConsole()
-    if console and console:IsShown() then
+    if consoleFrame and consoleFrame:IsShown() then
         UI:HideDebugConsole()
     else
         UI:ShowDebugConsole()
     end
 end
+
+--------------------------
+-- Init
+--------------------------
+
+RegisterFlipQueueActions()

--- a/UI/SlashCommands.lua
+++ b/UI/SlashCommands.lua
@@ -478,7 +478,7 @@ end
 
 local function debugToggle()
     if not ns.db then return end
-    ns.db.settings.debugMessages = not ns.db.settings.debugMessages
+    ns:SetDebugEnabled(not ns.db.settings.debugMessages)
     ns:Print("Debug messages: " .. (ns.db.settings.debugMessages and
         ns.COLORS.GREEN .. "ON" or ns.COLORS.RED .. "OFF") .. "|r")
 end


### PR DESCRIPTION
## Summary

Replaces the hand-rolled debug console (frame chrome, action grid, log scroll, status row, toggle button) with a thin wrapper around Cogworks' debug toolkit (`Libs/Cogworks-1.0/Debug.lua`). Net **-207 LOC** on `UI/DebugConsole.lua`.

- `UI/DebugConsole.lua` registers FlipQueue's actions via \`cw:RegisterDebugAction\` and shows \`cw:CreateDebugConsole({ cog = \"FlipQueue\", savedvars = ns.db.debugConsole })\` on \`/fq debug\`. The cw console owns tabs (Actions/Inspectors/Profile/Log), resize, persistence, and the debug-echo toggle.
- \`ns:PrintDebug\` forwards to \`cw:DebugPrint(\"FlipQueue\", msg)\`; local \`ns._debugLog\` ring buffer drops (Cogworks owns the ring now).
- New \`ns:SetDebugEnabled(b)\` helper keeps \`ns.db.settings.debugMessages\` and \`cw:SetDebugEnabled\` in sync so chat-echo gating matches the saved preference across sessions. \`/fq debug\` toggle and the in-console toggle button both flow through it (the latter via \`OnHide\` writeback).
- \`UI:RegisterDebugAction\` stays as a backward-compatible alias.

## Behavior deltas worth flagging during review

- Debug chat-echo line now reads \`[FlipQueue debug]\` instead of \`FlipQueue [debug]:\` — closest the cw API permits without a custom prefix hook.
- The hand-rolled \"Toggle debug mode\" action drops; cw's built-in toggle button covers the same flip.
- Console title bar now reads \`FlipQueue — Debug\` (cw default) instead of \`FlipQueue Debug Console — v<ver>\`. Version is still on /fq state and is harvested by Copy Debug Log.

## Test plan

- [ ] \`/fq debug\` opens the cw console; tabs render Actions/Inspectors/Profile/Log
- [ ] \"Bank popup ×6\" / \"Bank popup ×60\" actions still trigger BankPopup correctly
- [ ] \"Copy debug log\" produces a populated export popup (header + recent entries)
- [ ] Toggling debug-echo via the in-console button persists across /reload (next-session chat shows or hides debug lines per saved state)
- [ ] \`/fq debug\` slash subcommand still toggles ns.db.settings.debugMessages and prints the ON/OFF confirmation
- [ ] No Lua errors at PLAYER_LOGIN

Part of #143 (Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)