### PR TITLE
fix(FQ-178): MiniView sell rows carry [POST] verb prefix

### DIFF
--- a/UI/MiniView.lua
+++ b/UI/MiniView.lua
@@ -687,14 +687,17 @@ function UI:RefreshMini()
                 statusTag = ns.COLORS.RED .. " [not found]" .. ns.COLORS.RESET
             end
 
-            -- Buy task prefix follows the lifecycle. Each step swap matches
-            -- the next physical action the player has to take:
-            --   browse / buy → AH               [BUY]
-            --   collect      → mailbox          [CHECK MAIL]
-            --   deposit      → warbank          [DEPOSIT]
-            -- Step advances are driven by Tracker.lua AH hooks (browse → buy
-            -- → collect on purchase) and bag detection (collect → deposit
-            -- once the item arrives in bags).
+            -- Action prefix. Sell rows previously had none, which let a
+            -- sell row sandwiched between buys disappear into the buy stack
+            -- (FQ-178). Every row now carries a colored verb prefix so the
+            -- action is identifiable at a glance:
+            --   sell                          [POST]        green
+            --   buy (browse / buy step)       [BUY]         cyan
+            --   buy (collect step)            [CHECK MAIL]  yellow
+            --   buy (deposit step)            [DEPOSIT]     orange
+            -- Step advances on buy tasks are driven by Tracker.lua AH hooks
+            -- (browse → buy → collect on purchase) and bag detection
+            -- (collect → deposit once the item arrives in bags).
             local namePrefix = ""
             if task._isBuy then
                 if task._buyStep == "collect" then
@@ -704,6 +707,8 @@ function UI:RefreshMini()
                 else
                     namePrefix = ns.COLORS.CYAN .. "[BUY] " .. ns.COLORS.RESET
                 end
+            else
+                namePrefix = ns.COLORS.GREEN .. "[POST] " .. ns.COLORS.RESET
             end
             local qtyStr = (task.quantity or 1) > 1 and (" x" .. (task.quantity or 1)) or ""
             row.text:SetText(statusIcon .. namePrefix .. ns.COLORS.WHITE .. task.name .. qtyStr .. ns.COLORS.RESET .. statusTag .. priceStr)


### PR DESCRIPTION
## Summary
- Sell rows in the MiniView now carry a colored `[POST]` prefix in green, mirroring the existing buy-row `[BUY]` / `[CHECK MAIL]` / `[DEPOSIT]` prefixes.
- Solves the sandwiched-sell-disappears-into-buy-stack problem reported in #178 (and reproduced live: 2 buys + 1 sell + 4 buys on one character → sell never got posted).
- One-line change to the `namePrefix` branch in `UI/MiniView.lua`; the buy-prefix logic stays the same.

## Test plan
- [ ] Mini overlay with a single sell task shows `[POST]` prefix in green ahead of the item name
- [ ] Mini overlay with a sandwiched sell (buys + sell + buys on one char) makes the sell row immediately distinguishable
- [ ] Buy-task prefixes ([BUY] / [CHECK MAIL] / [DEPOSIT]) still render in their existing colors
- [ ] Row mouseover, action buttons, and tooltip unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)