### PR TITLE
fix(FQ-179): TSM-skipped sell tasks auto-clear from active list

### DIFF
--- a/TodoList.lua
+++ b/TodoList.lua
@@ -1667,6 +1667,8 @@ end
 
 -- Check TSM thresholds for all pending tasks on the current character.
 -- Below-threshold items are either reassigned to a realm-mate or skipped.
+-- Skips create a log entry AND remove the task from the active list so
+-- TSM-rejected tasks don't linger as residue after a posting run (FQ-179).
 -- Returns: { reassigned = count, skipped = count }
 function TodoList:HandleTSMRejections()
     if not ns.db or not ns.db.settings.tsmAutoSkipRejected then
@@ -1685,6 +1687,11 @@ function TodoList:HandleTSMRejections()
     local currentRealm = charKey:match("%-(.+)$") or ""
     local results = { reassigned = 0, skipped = 0 }
     local messages = {}
+
+    -- Collect indices to remove. We can't table.remove during ipairs
+    -- because that shifts subsequent indices and skips entries. Reassigns
+    -- mutate in place safely; only skips need post-loop removal.
+    local toRemove = {}
 
     for taskIdx, task in ipairs(current.tasks) do
         -- Only check tasks that are pending, on this character, on this realm,
@@ -1721,15 +1728,14 @@ function TodoList:HandleTSMRejections()
                     table.insert(messages, ns.COLORS.CYAN .. "Reassigned:|r " ..
                         (task.name or "?") .. " -> " .. altName .. " (" .. reason .. ")")
                 else
-                    -- No alternate character — skip with reason
-                    task.status = "skipped"
-                    task.failReason = reason
+                    -- No alternate character — log the skip and queue task
+                    -- for removal. The log entry captures the rejection
+                    -- reason so the player can audit later via /fq log.
                     results.skipped = results.skipped + 1
                     table.insert(messages, ns.COLORS.ORANGE .. "Skipped:|r " ..
                         (task.name or "?") .. " (" .. reason .. ")")
 
-                    -- Log the rejection
-                    table.insert(ns.db.log, {
+                    local logEntry = {
                         itemKey        = task.itemKey,
                         itemID         = task.itemID,
                         name           = task.name,
@@ -1746,6 +1752,38 @@ function TodoList:HandleTSMRejections()
                         soldPrice      = nil,
                         postedQuantity = task.quantity or 1,
                         failReason     = reason,
+                    }
+                    table.insert(ns.db.log, logEntry)
+
+                    table.insert(toRemove, {
+                        taskIdx  = taskIdx,
+                        taskUUID = task.taskUUID,
+                        logEntry = logEntry,
+                        importSource = task.importSource,
+                        importKey    = task.importKey,
+                    })
+                end
+            end
+        end
+    end
+
+    -- Remove skipped tasks in reverse so earlier indices stay valid, then
+    -- propagate to the linked partner via TDLOG (same delta used by
+    -- MoveTaskToLog — partner inserts the log entry and removes the task).
+    if #toRemove > 0 then
+        table.sort(toRemove, function(a, b) return a.taskIdx > b.taskIdx end)
+        for _, entry in ipairs(toRemove) do
+            if entry.importSource and entry.importKey then
+                ns:ImportRemove(entry.importSource, entry.importKey)
+            end
+            table.remove(current.tasks, entry.taskIdx)
+        end
+        if ns.Sync and ns.Sync.IsLinked and ns.Sync:IsLinked() and not ns.Sync._applying then
+            for _, entry in ipairs(toRemove) do
+                if entry.taskUUID then
+                    ns.Sync:EmitDelta("TDLOG", {
+                        taskUUID = entry.taskUUID,
+                        logEntry = entry.logEntry,
                     })
                 end
             end
@@ -1759,6 +1797,11 @@ function TodoList:HandleTSMRejections()
     if results.reassigned + results.skipped > 0 then
         ns:Print(ns.COLORS.YELLOW .. "TSM threshold check:|r " ..
             results.reassigned .. " reassigned, " .. results.skipped .. " skipped")
+    end
+
+    -- If skipping cleared the last pending task on the list, archive it.
+    if results.skipped > 0 then
+        self:CheckAutoComplete()
     end
 
     return results


### PR DESCRIPTION
## Summary
- `TodoList:HandleTSMRejections` already wrote an `auctionStatus="skipped"` log entry for each below-threshold task, but it left the task in `active.tasks` with `status="skipped"`. UI surfaces filter `status=pending` so display was correct — but the persistent state grew with TSM-skip residue across sessions and partner-account sync never saw the skip.
- Fix: collect skip indices during the iteration, `table.remove` in reverse order after the loop, clean up the `ns.db.imports` source record (matches `MoveTaskToLog`), emit `TDLOG` delta for partner sync (re-uses the existing delta type used by `MoveTaskToLog` — partner inserts the log entry and removes the task), and call `CheckAutoComplete` so a list whose last pending tasks all TSM-skip archives cleanly.
- The reassign-to-alt-char branch is untouched (those tasks legitimately stay pending). Manual `SkipTask` is also unchanged.

## Test plan
- [ ] Open AH with a list that contains a below-threshold sell task and `tsmAutoSkipRejected=true` — task disappears from to-do (was previously left with status=skipped), log entry created with `auctionStatus=skipped` + failReason
- [ ] Same scenario with an alt-char available on the same realm — task reassigns, stays pending, no log entry (existing behavior preserved)
- [ ] Linked partner sees the skip propagate (log entry inserted, task removed)
- [ ] List of all-TSM-skip tasks auto-archives via CheckAutoComplete after the run
- [ ] Manual `/fq` skip still sets `status="skipped"` in place without log entry (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)