### PR TITLE
fix(FQ-177): pricesource diagnostic accepts shift-clicked item links

### DIFF
--- a/UI/SlashCommands.lua
+++ b/UI/SlashCommands.lua
@@ -1194,12 +1194,18 @@ local function debugPriceSource(rawQuery)
     -- it, otherwise the import record is lost and the trail goes cold.
     rawQuery = strtrim(rawQuery or "")
     if rawQuery == "" then
-        ns:Print("Usage: /fq debug pricesource <itemName or itemID>")
+        ns:Print("Usage: /fq debug pricesource <itemName or itemID or shift-clicked link>")
         return
     end
 
-    local query = rawQuery:lower()
-    local queryID = rawQuery:match("^(%d+)$")
+    -- Shift-clicked item links arrive with color codes stripped but the
+    -- `item:<id>:...` payload and bracketed `[Name]` envelope intact. Pull
+    -- the itemID and name out so link-clicks match the same way typed
+    -- queries do.
+    local linkItemID = rawQuery:match("item:(%d+)")
+    local linkName   = rawQuery:match("%[(.-)%]")
+    local queryID    = linkItemID or rawQuery:match("^(%d+)$")
+    local query      = (linkName or rawQuery):lower()
 
     local function NameMatches(name, itemID)
         local nm = (name or ""):lower()


### PR DESCRIPTION
## Summary
- Follow-up to #181. Shift-clicking an item into `/fq debug pricesource` was producing 0 matches because the matcher only handled bare item IDs or raw-text substring searches.
- After WoW strips the color envelope, the query arrives as `item:<id>:...:[Name]` — pull the itemID and bracketed name out of that form so link input hits the same code paths as typed input.
- Usage hint now lists the three accepted forms.

## Test plan
- [ ] `/fq debug pricesource` (no arg) prints the usage line.
- [ ] `/fq debug pricesource 258908` matches the to-do task with that itemID.
- [ ] `/fq debug pricesource crystal` partial-name match still works.
- [ ] Shift-clicking an item that exists in the active to-do prints its full diagnostic block.
- [ ] Shift-clicking an item *not* in the to-do prints "0 match(es)" cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)