### PR TITLE
fix(FQ-177): pricesource diagnostic reads task fields directly

### DIFF
--- a/UI/SlashCommands.lua
+++ b/UI/SlashCommands.lua
@@ -1221,9 +1221,8 @@ local function debugPriceSource(rawQuery)
 
     local matches = {}
     for taskIdx, task in ipairs(list.tasks) do
-        local it = task.item
-        if it and NameMatches(it.name, it.itemID) then
-            matches[#matches + 1] = { taskIdx = taskIdx, item = it }
+        if task and NameMatches(task.name, task.itemID) then
+            matches[#matches + 1] = { taskIdx = taskIdx, item = task }
         end
     end
 


### PR DESCRIPTION
## Summary
- Second follow-up to #181. The diagnostic was iterating `active.tasks` and reading `task.item.name`, but tasks store item fields flat on the task (`task.name`, `task.itemID`, `task.expectedPrice`, etc. — see `TodoList.lua:181-186` and `TodoGenerator.lua:1009-1034`). Result: every probe returned 0 matches even when the item was clearly in the list.
- Drop the `task.item` indirection. `m.item` in the match record now points at the task itself; downstream field reads (`it.itemKey`, `it.expectedPrice`, `it.importSource`, …) work unchanged.

## Test plan
- [ ] `/fq debug pricesource Tarnished Dawnlit Band` returns one or more matches against the current to-do.
- [ ] Shift-clicked item link still resolves via #184's link-extraction path.
- [ ] Match block prints itemKey, expectedPrice, importSource, importRec.*, and live TSM prices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)