### PR TITLE
feat(FQ-187): inventory-aware regenerate (buy-conversion + underwater filter)

### DIFF
--- a/TodoList.lua
+++ b/TodoList.lua
@@ -232,6 +232,40 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
     refreshMode = refreshMode or "fpsaved"
     removedKeys = removedKeys or {}
 
+    -- Inventory pool keyed by itemKey AND by numericID (so a bonus-id
+    -- variant in bags counts as "have it" against the base sell task).
+    local pool = self:BuildItemPool()
+    local poolByKey, poolByID = {}, {}
+    for _, p in ipairs(pool) do
+        poolByKey[p.itemKey] = p
+        local numID = tonumber(p.itemID)
+        if numID then poolByID[numID] = p end
+    end
+
+    -- Cheapest buy-side lookup from current fpCrossRealm imports. Used when
+    -- a sell task has lost its inventory and the original task wasn't a
+    -- cross-realm flip (so no preserved buyRealm/buyPrice). Best-effort
+    -- ad-hoc lookup; a proper research system tracks at FQ-192.
+    local buyByItemID = {}
+    if ns.db and ns.db.imports and ns.db.imports.fpCrossRealm then
+        for _, deal in pairs(ns.db.imports.fpCrossRealm) do
+            local numID = tonumber(deal.itemID)
+            if numID and deal.buyPrice and deal.buyRealm and deal.buyRealm ~= "" then
+                local g = ns.ParseGoldValue and ns:ParseGoldValue(deal.buyPrice) or 0
+                if g > 0 then
+                    local existing = buyByItemID[numID]
+                    if not existing or g < existing.priceGold then
+                        buyByItemID[numID] = {
+                            realm     = deal.buyRealm,
+                            price     = deal.buyPrice,
+                            priceGold = g,
+                        }
+                    end
+                end
+            end
+        end
+    end
+
     local out = {}
     local tsmEnabled = refreshMode == "tsmlive"
         and ns.TSM and ns.TSM.IsEnabled and ns.TSM:IsEnabled()
@@ -249,18 +283,9 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
             copy.completedAt = nil
             copy.attempts = 0
 
-            -- Reset step states for the chosen action.
-            if copy.action == "buy" then
-                copy.steps = {
-                    browse = "pending", buy = "pending",
-                    collect = "pending", deposit = "pending",
-                }
-            else
-                copy.steps = {
-                    retrieve = "pending", post = "pending", collect = "pending",
-                }
-            end
-
+            ----------------------------------------------------------------
+            -- 1. Refresh price per chosen mode.
+            ----------------------------------------------------------------
             if refreshMode == "fpsaved" then
                 local importSource = task.importSource
                 local importKey    = task.importKey
@@ -270,7 +295,6 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                 if deal and ns.ResolveFPPrice then
                     copy.expectedPrice = ns:ResolveFPPrice(deal)
                 end
-                -- If no import record survives, keep the stored price.
             elseif tsmEnabled and copy.itemKey then
                 local tsmCopper = ns.TSM:GetPrice(copy.itemKey, "DBRegionMarketAvg")
                 if not tsmCopper or tsmCopper <= 0 then
@@ -281,6 +305,72 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                     copy.priceSource   = "TSM live"
                     copy.priceUpdatedAt = time()
                 end
+            end
+
+            ----------------------------------------------------------------
+            -- 2. Inventory check (sell tasks only). If we don't have it,
+            --    try to turn this into a buy task using preserved cross-
+            --    realm fields or current fpCrossRealm data. Otherwise mark
+            --    needs-acquire.
+            ----------------------------------------------------------------
+            local isSell = (copy.action == nil) or (copy.action == "sell")
+            local numID  = tonumber(copy.itemID)
+            local hasInventory = (copy.itemKey and poolByKey[copy.itemKey])
+                or (numID and poolByID[numID])
+
+            if isSell and not hasInventory then
+                local preservedFlip = task.buyRealm and task.buyPrice
+                    and task.buyRealm ~= "" and task.buyPrice ~= ""
+                local lookup = numID and buyByItemID[numID]
+
+                if preservedFlip then
+                    copy.action   = "buy"
+                    copy.buyRealm = task.buyRealm
+                    copy.buyPrice = task.buyPrice
+                    copy.dealType = "buy"
+                    copy._regenNote = "no inventory \xe2\x86\x92 buy"
+                elseif lookup then
+                    copy.action   = "buy"
+                    copy.buyRealm = lookup.realm
+                    copy.buyPrice = lookup.price
+                    copy.dealType = "buy"
+                    copy._regenNote = "no inventory \xe2\x86\x92 buy"
+                else
+                    copy.status     = "skipped"
+                    copy.failReason = "No inventory and no known buy source"
+                    copy._regenNote = "needs acquire"
+                end
+            end
+
+            ----------------------------------------------------------------
+            -- 3. Underwater check: if a sell task's expectedPrice would be
+            --    below TSM's minimum, commit it as skipped so it shows in
+            --    the log but doesn't pop the active list.
+            ----------------------------------------------------------------
+            if hasInventory and isSell and copy.status == "pending"
+               and ns.TSM and ns.TSM.IsBelowThreshold and ns.TSM:IsEnabled() then
+                local below, ahMin, threshold = ns.TSM:IsBelowThreshold(copy.itemKey or "")
+                if below then
+                    copy.status = "skipped"
+                    local threshStr = threshold and ns.TSM.FormatCopper
+                        and ns.TSM:FormatCopper(threshold) or "?"
+                    copy.failReason = "Below TSM min (" .. threshStr .. ")"
+                    copy._regenNote = "below market"
+                end
+            end
+
+            ----------------------------------------------------------------
+            -- 4. Reset step states AFTER action may have flipped to buy.
+            ----------------------------------------------------------------
+            if copy.action == "buy" then
+                copy.steps = {
+                    browse = "pending", buy = "pending",
+                    collect = "pending", deposit = "pending",
+                }
+            else
+                copy.steps = {
+                    retrieve = "pending", post = "pending", collect = "pending",
+                }
             end
 
             out[#out + 1] = copy

--- a/UI/GeneratorRegenerateTrack.lua
+++ b/UI/GeneratorRegenerateTrack.lua
@@ -73,6 +73,10 @@ local function CreateTaskRow(parent)
     row.action:SetTextColor(0.5, 0.8, 1)
     row.action:SetPoint("LEFT", row, "LEFT", 380, 0)
 
+    row.note = CreateLabel(row, "")
+    row.note:SetTextColor(0.7, 0.55, 0.45)
+    row.note:SetPoint("LEFT", row, "LEFT", 460, 0)
+
     row.xBtn = CreateFrame("Button", nil, row, "BackdropTemplate")
     row.xBtn:SetSize(18, 18)
     row.xBtn:SetPoint("RIGHT", row, "RIGHT", -6, 0)
@@ -408,7 +412,21 @@ local function RenderStep3(gf, refresh, contentTop)
         return
     end
 
-    r3.previewLabel:SetText(string.format("Preview (%d tasks, showing first 50):", #preview.tasks))
+    -- Count states for the header summary
+    local nSell, nBuy, nSkipped = 0, 0, 0
+    for _, t in ipairs(preview.tasks) do
+        if t.status == "skipped" then
+            nSkipped = nSkipped + 1
+        elseif t.action == "buy" then
+            nBuy = nBuy + 1
+        else
+            nSell = nSell + 1
+        end
+    end
+    r3.previewLabel:SetText(string.format(
+        "Preview (%d tasks):  %d post  |  %d buy  |  %d skipped",
+        #preview.tasks, nSell, nBuy, nSkipped))
+
     local y = -2
     local shown = math.min(50, #preview.tasks)
     for i = 1, shown do
@@ -424,8 +442,26 @@ local function RenderStep3(gf, refresh, contentTop)
         row:SetPoint("RIGHT",   r3.scrollContent, "RIGHT", -4, 0)
         row.name:SetText(task.name or "?")
         row.char:SetText(task.assignedChar or "(no char)")
-        row.action:SetText(task.action == "buy" and "BUY" or "POST")
         row.price:SetText(task.expectedPrice or "")
+        row.note:SetText(task._regenNote or "")
+
+        if task.status == "skipped" then
+            row.bg:SetColorTexture(0.18, 0.12, 0.06, 0.7)
+            row.name:SetTextColor(0.7, 0.6, 0.5)
+            row.action:SetText("SKIP")
+            row.action:SetTextColor(0.9, 0.6, 0.3)
+        elseif task.action == "buy" then
+            row.bg:SetColorTexture(0.05, 0.13, 0.18, 0.7)
+            row.name:SetTextColor(1, 1, 1)
+            row.action:SetText("BUY")
+            row.action:SetTextColor(0.4, 0.8, 1)
+        else
+            row.bg:SetColorTexture(0.06, 0.10, 0.07, 0.7)
+            row.name:SetTextColor(1, 1, 1)
+            row.action:SetText("POST")
+            row.action:SetTextColor(0.4, 0.9, 0.4)
+        end
+
         row:Show()
         y = y - ROW_H - 1
     end


### PR DESCRIPTION
Iterates on the Regenerate track (PR #188). Follow-up #192 filed for proper price-research.

## Summary

Three behavior changes to `TodoList:RegenerateList`:

1. **Inventory check.** Builds `BuildItemPool` (any char's bags + warbank, indexed by itemKey AND numericID). Sell tasks whose item is no longer in inventory get auto-converted:
   - Cross-realm flip in source -> reuse preserved `buyRealm` + `buyPrice`.
   - Otherwise scan `fpCrossRealm` for the cheapest realm carrying that itemID.
   - No data -> commit as `status=skipped` with failReason "No inventory and no known buy source".

2. **Underwater filter.** Sell tasks where the regenerated `expectedPrice` is below TSM's reject threshold (`TSM:IsBelowThreshold`) commit as `status=skipped` with failReason "Below TSM min (...)". They appear in the preview marked "below market" and in the log post-commit, but don't pop the active list or mini-view.

3. **Step-state reset moved after action flip.** Buy-converted tasks now correctly get the `browse/buy/collect/deposit` chain instead of the sell chain.

## Preview UI (Step 3)

- Header summary: "X post  |  Y buy  |  Z skipped"
- Per-row tag + tint:
  - POST (green) - ready-to-post sell
  - BUY  (cyan)  - converted, item missing
  - SKIP (orange) - underwater or needs-acquire
- New note column: "no inventory -> buy" / "below market" / "needs acquire"

## Test plan

- [ ] Regenerate active list with all items present. All rows show POST (green); skipped count = 0.
- [ ] Delete an item from bags, regenerate. That row shows BUY (cyan) if cross-realm or fpCrossRealm has it; SKIP (orange) "needs acquire" otherwise.
- [ ] Run regenerate with `fpPriceSource = Sale Avg`. Items where Sale Avg < TSM min show SKIP (orange) "below market". Save. The active list should NOT include those.
- [ ] Save with mix of POST / BUY / SKIP. Tracker shows the active tasks (POST + BUY); log shows skipped reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)