### PR TITLE
feat(FQ-187): Regenerate tsmlive uses player's Auctioning op normalPrice

### DIFF
--- a/TSM.lua
+++ b/TSM.lua
@@ -594,6 +594,41 @@ function TSM:EvaluateOpPrice(fqKey, expression)
     return nil
 end
 
+-- Evaluate the player's Auctioning operation normalPrice for an item.
+-- Mirrors AuctionPost:ResolvePostPrice's op resolution but skips the
+-- live AH state + decision tree -- callers that just need the "what
+-- would TSM recommend posting at" copper value should use this.
+--
+-- Returns: normalCopper, opName  (either may be nil if no op is bound
+-- to the item or the expression doesn't evaluate).
+function TSM:GetOpNormalPrice(fqKey)
+    if not self:IsEnabled() then return nil, nil end
+    if not fqKey or fqKey == "" then return nil, nil end
+
+    -- AuctioningOpNormal is TSM's built-in source key that resolves to
+    -- the active Auctioning op's normalPrice for the bound item. Try
+    -- it first -- avoids a separate group lookup round-trip when TSM
+    -- can answer directly.
+    local copper = self:EvaluateOpPrice(fqKey, "AuctioningOpNormal")
+    local op     = self:GetItemAuctioningOp(fqKey)
+    local opName = op and op.opName or nil
+    if copper and copper > 0 then
+        return copper, opName
+    end
+
+    -- Fallback: pull the expression off the op record and evaluate
+    -- directly. Covers items where TSM groups the item but the built-
+    -- in key fails (rare; usually a stale group cache).
+    if op and op.normalPrice then
+        copper = self:EvaluateOpPrice(fqKey, op.normalPrice)
+        if copper and copper > 0 then
+            return copper, opName
+        end
+    end
+
+    return nil, opName
+end
+
 -- Walk group hierarchy to find effective operation (handles inheritance)
 function TSM:ResolveGroupOperation(groupsDB, groupPath, moduleName)
     local groupData = groupsDB[groupPath]

--- a/TodoList.lua
+++ b/TodoList.lua
@@ -296,14 +296,28 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                     copy.expectedPrice = ns:ResolveFPPrice(deal)
                 end
             elseif tsmEnabled and copy.itemKey then
-                local tsmCopper = ns.TSM:GetPrice(copy.itemKey, "DBRegionMarketAvg")
-                if not tsmCopper or tsmCopper <= 0 then
-                    tsmCopper = ns.TSM:GetPrice(copy.itemKey, "DBMinBuyout")
-                end
-                if tsmCopper and tsmCopper > 0 and ns.FormatGold then
-                    copy.expectedPrice = ns:FormatGold(tsmCopper)
-                    copy.priceSource   = "TSM live"
+                -- Prefer the player's Auctioning operation normalPrice so
+                -- expectedPrice reflects their actual recommended posting
+                -- price (e.g. `max(DBMinBuyout-1c, 250% DBRegionMarketAvg)`)
+                -- rather than a raw single-source lookup. Fall back through
+                -- DBRegionMarketAvg / DBMinBuyout only when the item isn't
+                -- bound to an op so the regen still produces a price.
+                local opCopper, opName = ns.TSM.GetOpNormalPrice
+                    and ns.TSM:GetOpNormalPrice(copy.itemKey)
+                if opCopper and opCopper > 0 and ns.FormatGold then
+                    copy.expectedPrice = ns:FormatGold(opCopper)
+                    copy.priceSource   = "TSM op" .. (opName and (": " .. opName) or "")
                     copy.priceUpdatedAt = time()
+                else
+                    local tsmCopper = ns.TSM:GetPrice(copy.itemKey, "DBRegionMarketAvg")
+                    if not tsmCopper or tsmCopper <= 0 then
+                        tsmCopper = ns.TSM:GetPrice(copy.itemKey, "DBMinBuyout")
+                    end
+                    if tsmCopper and tsmCopper > 0 and ns.FormatGold then
+                        copy.expectedPrice = ns:FormatGold(tsmCopper)
+                        copy.priceSource   = "TSM live (no op)"
+                        copy.priceUpdatedAt = time()
+                    end
                 end
             end
 

--- a/UI/GeneratorRegenerateTrack.lua
+++ b/UI/GeneratorRegenerateTrack.lua
@@ -188,8 +188,8 @@ function RegenerateTrack:Init(gf)
     r3.modeFp.desc:SetPoint("TOPLEFT", r3.modeFp.label, "BOTTOMLEFT", 0, -2)
 
     r3.modeTsm = CreateRadio(r3,
-        "Use live TSM prices",
-        "Looks up DBRegionMarketAvg per item right now. Requires TSM.")
+        "Use my TSM op",
+        "Evaluates your Auctioning operation's normalPrice expression per item (e.g. complex DBMinBuyout-based formulas). Falls back to DBRegionMarketAvg for items not bound to an op. Requires TSM.")
     r3.modeTsm:SetPoint("TOPLEFT", r3.modeFp.desc, "BOTTOMLEFT", -24, -6)
     r3.modeTsm.label:SetPoint("LEFT", r3.modeTsm, "RIGHT", 4, 0)
     r3.modeTsm.desc:SetPoint("TOPLEFT", r3.modeTsm.label, "BOTTOMLEFT", 0, -2)


### PR DESCRIPTION
Iterates on FQ-187. The Regenerate track's **Use live TSM** mode was reading `DBRegionMarketAvg` directly — ignoring any complex posting expression the player has set up in their TSM Auctioning operation. Underwater detection already routes through the op's `minPrice` via `TSM:IsBelowThreshold`; this aligns price-setting with the same logic.

## Changes

- **`TSM:GetOpNormalPrice(fqKey)`** (new helper) — mirrors the op resolution in `AuctionPost:ResolvePostPrice` but skips the live AH state + decision tree. Tries `AuctioningOpNormal` builtin first (short-circuits group cache lookup), falls back to evaluating the op record's `normalPrice` expression.
- **`RegenerateList` tsmlive branch** — uses `GetOpNormalPrice`. Tags `priceSource = "TSM op: <opName>"`. Falls back to `DBRegionMarketAvg` / `DBMinBuyout` only when the item is ungrouped; tags `priceSource = "TSM live (no op)"` so the diagnostic surfaces which path fired.
- **Step 3 radio renamed**: "Use my TSM op" with updated description mentioning the normalPrice expression eval.

## Test plan
- [ ] Items in a TSM Auctioning group with a complex normalPrice formula come back with that formula's value (not a raw single-source average).
- [ ] `/fq debug pricesource <item>` after regen shows `priceSource: TSM op: <name>`.
- [ ] Items not bound to any op fall back to DBRegionMarketAvg, tagged `TSM live (no op)`.
- [ ] Underwater detection still fires correctly (same `IsBelowThreshold` path, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)