### PR TITLE
fix(FQ-195): correct Auctionator search-string field shift

### DIFF
--- a/BuyListSync.lua
+++ b/BuyListSync.lua
@@ -90,8 +90,15 @@ local function BuildSearchString(item, opts)
         end
     end
 
-    -- Field order: name;cat;minIlvl;maxIlvl;minLvl;maxLvl;minCLvl;maxCLvl;minPrice;maxPrice;quality;tier;exp;qty
-    return name .. ";;" .. ilvlMin .. ";" .. ilvlMax .. ";;;;;" .. priceStr .. ";" .. qualStr .. ";" .. tierStr .. ";;"
+    -- Field order: name(1);cat(2);minIlvl(3);maxIlvl(4);minLvl(5);maxLvl(6);
+    --              minCLvl(7);maxCLvl(8);minPrice(9);maxPrice(10);quality(11);
+    --              tier(12);exp(13);qty(14)
+    -- priceStr is the maxPrice ceiling. There must be 6 separators between
+    -- maxIlvl and priceStr (4 -> 10), one for each empty field minLvl ..
+    -- minPrice. An earlier version dropped one and priceStr landed in
+    -- minPrice's slot -- which made Auctionator filter buy >= price
+    -- instead of <= price, the exact reverse of what we want.
+    return name .. ";;" .. ilvlMin .. ";" .. ilvlMax .. ";;;;;;" .. priceStr .. ";" .. qualStr .. ";" .. tierStr .. ";;"
 end
 
 -- Walk active buy tasks for the current character, filter to "still needed",


### PR DESCRIPTION
Critical regression introduced by #196.

The 14-field Auctionator advanced-search format is positional:

```
name(1);cat(2);minIlvl(3);maxIlvl(4);minLvl(5);maxLvl(6);minCLvl(7);maxCLvl(8);minPrice(9);maxPrice(10);quality(11);tier(12);exp(13);qty(14)
```

I dropped one semicolon when inserting the new minIlvl/maxIlvl fields, so `priceStr` (intended as `maxPrice`) landed in `minPrice`. Auctionator filtered **buy >= price** instead of **buy <= price** — the exact reverse — and the ilvl bounds appeared to silently fail because the broken field count threw off Auctionator's parser.

## Fix
- One missing semicolon between `maxIlvl` and `maxPrice` (now 6 separators between them — one for each empty field `minLvl..minPrice`).
- Comment above the return spells out the position-by-field expectation so the next person editing this string sees the alignment.

## Test plan
- [ ] After merge, push to Auctionator. The shopping-list entry's price field now reads as "below 200g" (or whatever the buy price is), not "above 200g".
- [ ] Search the list in-game — only listings <= price appear.
- [ ] ilvl-220 task produces a search string with ilvl bounds 220 - 220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)