### PR TITLE
feat(FQ-157): archive old to-do lists instead of deleting them

### DIFF
--- a/DB.lua
+++ b/DB.lua
@@ -31,6 +31,12 @@ function ns:InitDB()
     -- snapshot ({ name, tasks, importType }). Treated read-only by the
     -- regenerate flow; new lists go through CommitList per usual.
     db.todoLists.templates = db.todoLists.templates or {}
+    -- Archive of finished / discarded / replaced lists (FQ-157). Array of
+    -- { list = <snapshot>, archivedAt = epoch, reason = "completed" /
+    -- "discarded" / "replaced" }. Most recent first; capped to 50 entries
+    -- so it doesn't unbounded-grow. Surfaced as a source in the Regenerate
+    -- track Step 1 so old lists can be rebuilt.
+    db.todoLists.archive = db.todoLists.archive or {}
     db.log          = db.log or {}
     db.doNotTrack   = db.doNotTrack or {}
     db.sync         = db.sync or {}

--- a/TodoList.lua
+++ b/TodoList.lua
@@ -24,6 +24,9 @@ function TodoList:CommitList(preview, mode)
     end
 
     if mode == "replace" then
+        if ns.db.todoLists.active then
+            self:ArchiveList(ns.db.todoLists.active, "replaced")
+        end
         ns.db.todoLists.active = preview
     elseif mode == "append" then
         if not ns.db.todoLists.active or not ns.db.todoLists.active.tasks then
@@ -55,17 +58,47 @@ function TodoList:AdvanceQueue()
     return false
 end
 
+-- Max archive entries kept; older ones get trimmed when over.
+local ARCHIVE_CAP = 50
+
+-- Push a list snapshot into the archive (FQ-157). reason is "completed" /
+-- "discarded" / "replaced". Most recent first so Regenerate-track source
+-- picker shows newest history at the top. Cap keeps the saved-vars file
+-- from growing forever; players who want indefinite history can bump the
+-- constant later.
+function TodoList:ArchiveList(list, reason)
+    if not list or not list.tasks then return end
+    if not ns.db or not ns.db.todoLists then return end
+    ns.db.todoLists.archive = ns.db.todoLists.archive or {}
+    table.insert(ns.db.todoLists.archive, 1, {
+        list       = list,
+        archivedAt = time(),
+        reason     = reason or "discarded",
+    })
+    while #ns.db.todoLists.archive > ARCHIVE_CAP do
+        table.remove(ns.db.todoLists.archive)
+    end
+end
+
 -- Delete an upcoming list by index
 function TodoList:DeleteQueuedList(index)
     if not ns.db or not ns.db.todoLists then return end
-    if ns.db.todoLists.upcoming[index] then
+    local list = ns.db.todoLists.upcoming[index]
+    if list then
+        self:ArchiveList(list, "discarded")
         table.remove(ns.db.todoLists.upcoming, index)
     end
 end
 
--- Clear the active list and auto-promote the next queued list
-function TodoList:ClearCurrent()
+-- Clear the active list and auto-promote the next queued list.
+-- reason flows to the archive entry: defaults to "discarded" (manual x
+-- button on the active row) and is overridden to "completed" by
+-- CheckAutoComplete when all tasks reached a terminal state.
+function TodoList:ClearCurrent(reason)
     if not ns.db or not ns.db.todoLists then return end
+    if ns.db.todoLists.active then
+        self:ArchiveList(ns.db.todoLists.active, reason or "discarded")
+    end
     ns.db.todoLists.active = nil
 
     if ns.Sync and ns.Sync.IsLinked and ns.Sync:IsLinked() and not ns.Sync._applying then
@@ -205,6 +238,27 @@ function TodoList:GetRegenSources()
             label = name,
             list  = snapshot,
         }
+    end
+    -- Archived lists: most-recent-first, suffixed with the archive reason so
+    -- the picker can distinguish a finished list from one the player threw
+    -- away. The archive is capped, so a long-running install never grows
+    -- the source picker beyond a manageable count.
+    for i, entry in ipairs(ns.db.todoLists.archive or {}) do
+        if entry.list and entry.list.tasks then
+            local label = entry.list.name or "Unnamed"
+            local reason = entry.reason or "?"
+            local age = entry.archivedAt and ns.FormatRelativeTime
+                and ns:FormatRelativeTime(entry.archivedAt) or nil
+            local tag = "(" .. reason .. (age and (" " .. age) or "") .. ")"
+            sources[#sources + 1] = {
+                kind        = "archive",
+                label       = label .. " " .. tag,
+                list        = entry.list,
+                archiveIdx  = i,
+                archivedAt  = entry.archivedAt,
+                reason      = reason,
+            }
+        end
     end
     return sources
 end
@@ -1678,7 +1732,7 @@ function TodoList:CheckAutoComplete()
     end
 
     ns:Print(ns.COLORS.GREEN .. "All tasks completed or skipped — archiving to-do list.|r")
-    self:ClearCurrent()
+    self:ClearCurrent("completed")
 
     return changed
 end


### PR DESCRIPTION
Partial address of #157 — old to-do lists now persist after completion/discard/replacement and surface in the Regenerate Step 1 picker so they can be rebuilt.

## Changes

- **`db.todoLists.archive`** — new array, most-recent-first. Entries: `{ list, archivedAt, reason }`. Cap 50 with FIFO trim.
- **`TodoList:ArchiveList(list, reason)`** — new helper. Called by:
  - `ClearCurrent(reason)` — manual x → "discarded", `CheckAutoComplete` → "completed"
  - `DeleteQueuedList(index)` — "discarded"
  - `CommitList(preview, "replace")` — "replaced"
- **`GetRegenSources`** — appends archive entries with `kind = "archive"` and label like `"My list (completed 2h ago)"`.

## Test plan

- [ ] Complete an active list (all tasks reach terminal state) → check Regenerate Step 1, the old list appears tagged "(completed N ago)".
- [ ] Click the x on an active list → appears tagged "(discarded N ago)".
- [ ] Save a new regenerated list while one is active → the previous appears tagged "(replaced N ago)".
- [ ] Delete a queued list → appears tagged "(discarded N ago)".
- [ ] Trim test: after 51+ archives, oldest is dropped.

## Follow-up
Dedicated history view (browse/restore/delete archived lists) tracks separately on #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)