### PR TITLE
fix(FQ-195): backfill ilvl from import record on regenerate

### DIFF
--- a/TodoList.lua
+++ b/TodoList.lua
@@ -346,8 +346,19 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                 local bucket = importSource and ns.db
                     and ns.db.imports and ns.db.imports[importSource]
                 local deal = bucket and importKey and bucket[importKey]
-                if deal and ns.ResolveFPPrice then
-                    copy.expectedPrice = ns:ResolveFPPrice(deal)
+                if deal then
+                    if ns.ResolveFPPrice then
+                        copy.expectedPrice = ns:ResolveFPPrice(deal)
+                    end
+                    -- Backfill ilvl from the import record when the source
+                    -- task didn't carry it. Older tasks predate the
+                    -- TodoGenerator.lua change that started copying
+                    -- deal.ilvl onto taskEntry (FQ-195); Regenerate is the
+                    -- only path that can heal them without forcing the
+                    -- player to re-import.
+                    if (not copy.ilvl or copy.ilvl == 0) and deal.ilvl then
+                        copy.ilvl = deal.ilvl
+                    end
                 end
             elseif tsmEnabled and copy.itemKey then
                 -- Prefer the player's Auctioning operation normalPrice so


### PR DESCRIPTION
After #197 fixed the field-shift, the buy/sell math is correct again but ilvl bounds still don't appear. Root cause: existing to-do tasks were generated **before** #196 added `ilvl = deal.ilvl` to TodoGenerator's taskEntry constructors, so those tasks have `task.ilvl == nil`. Regenerate copies fields verbatim, so the nil propagates through to BuildSearchString.

## Fix

When `refreshMode == "fpsaved"` and the import bucket still carries the original deal record, copy `deal.ilvl` onto the regenerated task if the task itself has none:

```lua
if (not copy.ilvl or copy.ilvl == 0) and deal.ilvl then
    copy.ilvl = deal.ilvl
end
```

Preserves any ilvl the source task already had (no clobber for tasks freshly generated under #196).

`tsmlive` mode doesn't have a deal record to read from. Those tasks need a fresh `/fq generate` to pick up ilvl — flag for testing.

## Test plan
- [ ] Take an existing pre-fix active list, regenerate via Regenerate track with FP-saved mode, push to Auctionator. Shopping-list entries now carry ilvl bounds.
- [ ] Same flow with TSM-live mode: ilvl still missing for pre-fix tasks (expected — documented limitation, fresh generate is the workaround).
- [ ] Fresh `/fq generate` produces tasks with ilvl from the start (already tested under #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)