### PR TITLE
fix(FQ-195): broaden ilvl backfill to inventory pool + GetItemInfo

### DIFF
--- a/TodoList.lua
+++ b/TodoList.lua
@@ -346,18 +346,50 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                 local bucket = importSource and ns.db
                     and ns.db.imports and ns.db.imports[importSource]
                 local deal = bucket and importKey and bucket[importKey]
-                if deal then
-                    if ns.ResolveFPPrice then
-                        copy.expectedPrice = ns:ResolveFPPrice(deal)
-                    end
-                    -- Backfill ilvl from the import record when the source
-                    -- task didn't carry it. Older tasks predate the
-                    -- TodoGenerator.lua change that started copying
-                    -- deal.ilvl onto taskEntry (FQ-195); Regenerate is the
-                    -- only path that can heal them without forcing the
-                    -- player to re-import.
-                    if (not copy.ilvl or copy.ilvl == 0) and deal.ilvl then
+                if deal and ns.ResolveFPPrice then
+                    copy.expectedPrice = ns:ResolveFPPrice(deal)
+                end
+                -- Backfill ilvl on tasks that predate the TodoGenerator
+                -- ilvl propagation (FQ-195). Three sources in priority
+                -- order; first hit wins:
+                --   1. Original import record (gone if CommitList already
+                --      cleared imports — common case)
+                --   2. Inventory pool — sell tasks usually have the item
+                --      in bags or warbank with ilvl preserved from scan
+                --   3. C_Item.GetItemInfo base ilvl — last resort, no
+                --      bonus-id awareness but better than no bound
+                if not copy.ilvl or copy.ilvl == 0 then
+                    -- 1. Import record (most authoritative for FP-imported
+                    --    tasks; usually empty after CommitList clears imports)
+                    if deal and deal.ilvl and deal.ilvl > 0 then
                         copy.ilvl = deal.ilvl
+                    end
+                    -- 2. Inventory pool (sell tasks usually have the item;
+                    --    poolItem carries per-bonus-variant ilvl from scan)
+                    if (not copy.ilvl or copy.ilvl == 0) then
+                        local lookupID = tonumber(copy.itemID)
+                        local p = poolByKey[copy.itemKey or ""]
+                            or (lookupID and poolByID[lookupID])
+                        if p and p.ilvl and p.ilvl > 0 then
+                            copy.ilvl = p.ilvl
+                        end
+                    end
+                    -- 3. Resolve through the bonus-id-aware WoW API. The
+                    --    itemKey carries bonusIDs (e.g. `258908;12769:6652:13668;`)
+                    --    that bump the variant's ilvl; ItemKeyToItemString
+                    --    builds the canonical item string and
+                    --    GetDetailedItemLevelInfo evaluates it. This is the
+                    --    workhorse for buy tasks that have no inventory.
+                    if (not copy.ilvl or copy.ilvl == 0)
+                       and ns.ItemKeyToItemString and GetDetailedItemLevelInfo
+                       and copy.itemKey and copy.itemKey ~= "" then
+                        local wowStr = ns:ItemKeyToItemString(copy.itemKey)
+                        if wowStr then
+                            local ok, iLvl = pcall(GetDetailedItemLevelInfo, wowStr)
+                            if ok and iLvl and iLvl > 0 then
+                                copy.ilvl = iLvl
+                            end
+                        end
                     end
                 end
             elseif tsmEnabled and copy.itemKey then

--- a/UI/SlashCommands.lua
+++ b/UI/SlashCommands.lua
@@ -1246,6 +1246,7 @@ local function debugPriceSource(rawQuery)
         print(string.format("--- task #%d: %s ---", m.taskIdx, it.name or "?"))
         print("  itemKey:      " .. tostring(it.itemKey))
         print("  itemID:       " .. tostring(it.itemID))
+        print("  ilvl:         " .. tostring(it.ilvl or "(unset)"))
         print("  targetRealm:  " .. tostring(it.targetRealm))
         if it.action == "buy" then
             print("  action:       buy")


### PR DESCRIPTION
PR #199's backfill only worked for tasks whose original import record still existed in `ns.db.imports`. CommitList clears imports after every commit (TodoList.lua:47), so in practice the deal record is gone by the time Regenerate runs.

**Key insight from in-game testing**: the to-do view shows the correct ilvl on the item link (rendered from bonus IDs via WoW's API), even though `task.ilvl` is nil. Fix needs to compute ilvl from the bonus-ID-aware itemKey, not just look up stored fields.

## Four sources, first hit wins

1. **Import record** — same as #199. Rare hit but cheap to check.
2. **Inventory pool** (`BuildItemPool`) — `poolItem.ilvl` is per-bonus-variant from the Syndicator scan. Hits for sell tasks.
3. **`ns:ItemKeyToItemString` + `GetDetailedItemLevelInfo`** — *new workhorse*. Converts the task's itemKey (e.g. `258908;12769:6652:13668;`) to a WoW item string and asks WoW for the actual ilvl. Bonus-ID-aware. Hits for buy tasks (no inventory) and is the right answer for any item with bonus IDs.

## Diagnostic

`/fq debug pricesource` now prints `ilvl: 220` (or "(unset)") so we can confirm what the task carries.

## Test plan
- [ ] Regenerate an old list with FP-saved mode, push to Auctionator → ilvl bounds appear in the shopping list (220-220 for the Tarnished Dawnlit Band test class).
- [ ] `/fq debug pricesource Tarnished Dawnlit Band` shows the correct ilvl.
- [ ] Buy task (no inventory) → still gets ilvl via the GetDetailedItemLevelInfo path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)