### PR TITLE
fix(FQ-195): ilvl backfill for ALL regen modes + importKey suffix parse

### DIFF
--- a/TodoList.lua
+++ b/TodoList.lua
@@ -340,57 +340,15 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
             ----------------------------------------------------------------
             -- 1. Refresh price per chosen mode.
             ----------------------------------------------------------------
+            local importSource = task.importSource
+            local importKey    = task.importKey
+            local bucket = importSource and ns.db
+                and ns.db.imports and ns.db.imports[importSource]
+            local deal = bucket and importKey and bucket[importKey]
+
             if refreshMode == "fpsaved" then
-                local importSource = task.importSource
-                local importKey    = task.importKey
-                local bucket = importSource and ns.db
-                    and ns.db.imports and ns.db.imports[importSource]
-                local deal = bucket and importKey and bucket[importKey]
                 if deal and ns.ResolveFPPrice then
                     copy.expectedPrice = ns:ResolveFPPrice(deal)
-                end
-                -- Backfill ilvl on tasks that predate the TodoGenerator
-                -- ilvl propagation (FQ-195). Three sources in priority
-                -- order; first hit wins:
-                --   1. Original import record (gone if CommitList already
-                --      cleared imports — common case)
-                --   2. Inventory pool — sell tasks usually have the item
-                --      in bags or warbank with ilvl preserved from scan
-                --   3. C_Item.GetItemInfo base ilvl — last resort, no
-                --      bonus-id awareness but better than no bound
-                if not copy.ilvl or copy.ilvl == 0 then
-                    -- 1. Import record (most authoritative for FP-imported
-                    --    tasks; usually empty after CommitList clears imports)
-                    if deal and deal.ilvl and deal.ilvl > 0 then
-                        copy.ilvl = deal.ilvl
-                    end
-                    -- 2. Inventory pool (sell tasks usually have the item;
-                    --    poolItem carries per-bonus-variant ilvl from scan)
-                    if (not copy.ilvl or copy.ilvl == 0) then
-                        local lookupID = tonumber(copy.itemID)
-                        local p = poolByKey[copy.itemKey or ""]
-                            or (lookupID and poolByID[lookupID])
-                        if p and p.ilvl and p.ilvl > 0 then
-                            copy.ilvl = p.ilvl
-                        end
-                    end
-                    -- 3. Resolve through the bonus-id-aware WoW API. The
-                    --    itemKey carries bonusIDs (e.g. `258908;12769:6652:13668;`)
-                    --    that bump the variant's ilvl; ItemKeyToItemString
-                    --    builds the canonical item string and
-                    --    GetDetailedItemLevelInfo evaluates it. This is the
-                    --    workhorse for buy tasks that have no inventory.
-                    if (not copy.ilvl or copy.ilvl == 0)
-                       and ns.ItemKeyToItemString and GetDetailedItemLevelInfo
-                       and copy.itemKey and copy.itemKey ~= "" then
-                        local wowStr = ns:ItemKeyToItemString(copy.itemKey)
-                        if wowStr then
-                            local ok, iLvl = pcall(GetDetailedItemLevelInfo, wowStr)
-                            if ok and iLvl and iLvl > 0 then
-                                copy.ilvl = iLvl
-                            end
-                        end
-                    end
                 end
             elseif tsmEnabled and copy.itemKey then
                 -- Prefer the player's Auctioning operation normalPrice so
@@ -414,6 +372,50 @@ function TodoList:RegenerateList(sourceList, refreshMode, removedKeys, newName)
                         copy.expectedPrice = ns:FormatGold(tsmCopper)
                         copy.priceSource   = "TSM live (no op)"
                         copy.priceUpdatedAt = time()
+                    end
+                end
+            end
+
+            ----------------------------------------------------------------
+            -- 1b. Backfill ilvl on tasks that predate the TodoGenerator
+            --     propagation (FQ-195). Runs for both fpsaved AND tsmlive
+            --     modes so a TSM-op regen still picks up ilvl for the
+            --     Auctionator shopping-list export. Sources, first hit wins:
+            --       1. Original import record (rare; usually cleared)
+            --       2. Inventory pool (sell tasks)
+            --       3. importKey suffix ":iNNN" (FP encodes ilvl there)
+            --       4. ItemKeyToItemString + GetDetailedItemLevelInfo
+            --          (bonus-id-aware; works for any item with a key)
+            ----------------------------------------------------------------
+            if not copy.ilvl or copy.ilvl == 0 then
+                if deal and deal.ilvl and deal.ilvl > 0 then
+                    copy.ilvl = deal.ilvl
+                end
+                if not copy.ilvl or copy.ilvl == 0 then
+                    local lookupID = tonumber(copy.itemID)
+                    local p = poolByKey[copy.itemKey or ""]
+                        or (lookupID and poolByID[lookupID])
+                    if p and p.ilvl and p.ilvl > 0 then
+                        copy.ilvl = p.ilvl
+                    end
+                end
+                if (not copy.ilvl or copy.ilvl == 0)
+                   and copy.importKey and copy.importKey ~= "" then
+                    local fromKey = copy.importKey:match(":i(%d+)")
+                    if fromKey then
+                        local iv = tonumber(fromKey)
+                        if iv and iv > 0 then copy.ilvl = iv end
+                    end
+                end
+                if (not copy.ilvl or copy.ilvl == 0)
+                   and ns.ItemKeyToItemString and GetDetailedItemLevelInfo
+                   and copy.itemKey and copy.itemKey ~= "" then
+                    local wowStr = ns:ItemKeyToItemString(copy.itemKey)
+                    if wowStr then
+                        local ok, iLvl = pcall(GetDetailedItemLevelInfo, wowStr)
+                        if ok and iLvl and iLvl > 0 then
+                            copy.ilvl = iLvl
+                        end
                     end
                 end
             end


### PR DESCRIPTION
Diagnostic output showed `ilvl: (unset)` on tasks regenerated with **TSM op** mode. Cause: PR #200's backfill lived inside the `fpsaved` branch only — the `elseif tsmlive` path never touched ilvl.

## Changes

1. **Backfill runs once after price refresh, regardless of mode.** No more mode-coupling.
2. **New source: parse `:iNNN` from importKey.** FP encodes the captured ilvl as a suffix (`258909;;:i220|sargeras`). For tasks whose itemKey has no bonus IDs (`258909;;`), the WoW API only knows the base ilvl — this surfaces FP's ground-truth ilvl instead.

## Priority order

1. `deal.ilvl` (import record — usually gone after `CommitList`)
2. `pool.ilvl` (inventory scan — hits for sell tasks)
3. **`importKey :iNNN` suffix** (FP recorded at scan time) ← new
4. `GetDetailedItemLevelInfo` via `ItemKeyToItemString` (bonus-aware)

## Test plan
- [ ] Regenerate with TSM-op mode. `/fq debug pricesource <item>` shows `ilvl: 220` (not "(unset)").
- [ ] Push to Auctionator. Shopping list entries carry ilvl bounds.
- [ ] Verify still works in FP-saved mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)