### PR TITLE
fix(FQ-205): Deal Finder avoids realms with an active auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.13.0-alpha4
+
+Single feature: the Deal Finder now accounts for auctions the player already has posted (FQ-205 / #205). No other changes. Embedded Cogworks-1.0 stays at `v0.13.2`; no Phase B progress this cycle.
+
+This alpha ships without a maintainer in-game smoke test — the F8 gate was waived by the maintainer and the alpha is published for tester coverage.
+
+### FQ-205: Deal Finder avoids realms with an active auction
+
+The Deal Finder scored realms purely on TSM per-realm pricing and never consulted the active-auction log, so it could auto-assign a deal to a realm where the player was already posted. The duplicate was only caught at AH time by `TrackerAuctions:CheckOwnedAuctions` — after the warbank pull and the flight out — wasting the trip. The data to prevent it already existed in `ns.db.log`; the scan just wasn't reading it.
+
+`SalesIndex.lua` gains the index + query:
+
+- `BuildIndex` now also builds `activeByItem` — base itemID → set of posted target-realm display strings — from `auctionStatus == "active"` entries. The realm is kept as its raw display string (not normalized) so connected-realm matching works at query time.
+- `BaseItemID` (new local) mirrors `TrackerAuctions`' `EntryItemID`: `pet:<speciesID>` for battle pets, base itemID otherwise. Matching at this level keeps the "already posted" check in agreement with the AH-time reconciliation that removes the task across bonus/modifier variants.
+- `SalesIndex:HasActiveAuction(itemKey, targetRealm)` resolves the base ID and returns true if any posted realm shares a connected-realm AH with `targetRealm` via `ns:RealmsOverlap`.
+
+`DealFinder.lua`:
+
+- Each realm option built in `ScanChunked` now carries `hasActiveAuction` (`DealFinder.lua:311`).
+- `ApplyPriority` tracks the best *clean* (non-posted) realm alongside the best overall, and selects the clean one when `dfAvoidPostedRealms` is set — falling back to the best posted realm only when every candidate is posted. Deals are demoted, never dropped, and the player can still override. `group.selectedPosted` flags the all-posted fallback.
+
+`DB.lua` seeds `db.settings.dfAvoidPostedRealms = true` (default on — matches the behavior players already expect from inventory analysis).
+
+`UI/DealFinderPage.lua` adds the **"Avoid realms where I already have an auction posted"** checkbox to the Deal Finder config (with state restore). `UI/DealFinderDetail.lua` adds a `POSTED` flag and a two-line tooltip to each posted realm row in the selection grid; rows stay clickable so the player can deliberately add to an existing listing.
+
 ## v0.13.0-alpha3
 
 Third alpha on the v0.13.0 line. A single feature: the tools-drawer redesign (FQ-005 / #115), rebuilt around a declarative registry model. No other changes. Embedded Cogworks-1.0 stays at `v0.13.2`; no Phase B progress this cycle.

--- a/DB.lua
+++ b/DB.lua
@@ -276,6 +276,10 @@ function ns:InitDB()
     db.settings.dfOutlierMultiplier = db.settings.dfOutlierMultiplier or 1.5
     if db.settings.dfIgnoreOutliers == nil then db.settings.dfIgnoreOutliers = false end
     if db.settings.dfAbbreviatePct == nil then db.settings.dfAbbreviatePct = false end
+    -- Avoid auto-assigning deals to realms where an auction is already posted
+    -- (demote the posted realm so a clean one wins; #205). Default on: matches
+    -- the behavior players already expect from the inventory analysis.
+    if db.settings.dfAvoidPostedRealms == nil then db.settings.dfAvoidPostedRealms = true end
     db.settings.dfPriorityOrder = db.settings.dfPriorityOrder or {"profit", "noCompetition", "previousSales"}
     -- Skip deals that have no matching character (suppress "create character" tasks)
     if db.settings.skipUnassigned == nil then db.settings.skipUnassigned = false end

--- a/DealFinder.lua
+++ b/DealFinder.lua
@@ -136,10 +136,16 @@ end
 -- Sets _selected = true on best realm, false on others.
 function DealFinder:ApplyPriority(itemGroups, priorityOrder)
     priorityOrder = priorityOrder or (ns.db and ns.db.settings.dfPriorityOrder) or {"profit"}
+    local avoidPosted = ns.db and ns.db.settings.dfAvoidPostedRealms
 
     for _, group in ipairs(itemGroups) do
         if #group.realms > 0 then
+            -- Best realm overall, plus best among realms with no active auction.
+            -- When avoidPosted is on we prefer the clean pick and only fall back
+            -- to a posted realm when every candidate is already posted, so a deal
+            -- is demoted (not dropped) and the player can still override it.
             local bestIdx, bestScore = 1, -1
+            local cleanIdx, cleanScore = nil, -1
             for i, realmOpt in ipairs(group.realms) do
                 realmOpt.score = self:ScoreRealm(realmOpt, priorityOrder)
                 realmOpt._selected = false
@@ -147,9 +153,18 @@ function DealFinder:ApplyPriority(itemGroups, priorityOrder)
                     bestScore = realmOpt.score
                     bestIdx = i
                 end
+                if not realmOpt.hasActiveAuction and realmOpt.score > cleanScore then
+                    cleanScore = realmOpt.score
+                    cleanIdx = i
+                end
             end
-            group.realms[bestIdx]._selected = true
-            group.selectedRealm = bestIdx
+            local chosen = (avoidPosted and cleanIdx) or bestIdx
+            group.realms[chosen]._selected = true
+            group.selectedRealm = chosen
+            -- Flag the group when its auto-pick is still a posted realm (every
+            -- candidate was posted) so the UI can warn rather than silently
+            -- assign a realm the player is already on.
+            group.selectedPosted = group.realms[chosen].hasActiveAuction or false
         end
     end
 end
@@ -309,6 +324,7 @@ function DealFinder:ScanChunked(pool, onProgress, onComplete)
                             isOutlier     = isOutlier,
                             noCompetition = (numAuctions ~= nil and numAuctions == 0),
                             hasPreviousSales = (personalCount or 0) > 0,
+                            hasActiveAuction = ns.SalesIndex:HasActiveAuction(itemKey, targetRealm),
                             dataQuality   = dataQuality or "perRealm",
                             score         = 0,  -- set by ApplyPriority
                         })

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,18 @@ The engineering-detail companion lives in `CHANGELOG.md` (commit-readerese — f
 
 ---
 
+## v0.13.0-alpha4
+
+A focused alpha: the Deal Finder no longer sends items to realms you're already selling them on.
+
+### Deal Finder avoids realms you've already posted on
+
+Before, the Deal Finder could pick a realm where you already had that item up for sale. You'd fly there, pull from your warbank, open the auction house — and FlipQueue would spot the duplicate and drop the task, wasting the trip. Now it checks what you already have posted and steers each item to a realm you're *not* already on, moving to the next best realm instead.
+
+- **On by default.** Turn it off in Settings → Deal Finder ("Avoid realms where I already have an auction posted") if you'd rather rank every realm purely by price.
+- Realms you're already posted on are marked **POSTED** in the realm list. They stay selectable — if you do want to add to an existing listing, just click to pick one.
+- If *every* realm for an item is one you're already on, the item isn't dropped. FlipQueue still shows it and flags the situation so you can decide.
+
 ## v0.13.0-alpha3
 
 A focused alpha: the Tools drawer has been rebuilt from the ground up.

--- a/SalesIndex.lua
+++ b/SalesIndex.lua
@@ -45,6 +45,17 @@ local function NormalizeRealm(realm)
     return ns.NormalizeRealmKey and ns:NormalizeRealmKey(realm or "") or (realm or ""):lower()
 end
 
+-- Canonical item-ID key for matching across bonus/modifier variants. Mirrors
+-- TrackerAuctions' EntryItemID so the deal-finder "already posted" check agrees
+-- with the AH-time reconciliation that removes the task: battle pets get a
+-- "pet:<speciesID>" form, everything else collapses to its base itemID.
+local function BaseItemID(itemKey)
+    if not itemKey or itemKey == "" then return nil end
+    local petID = itemKey:match("^pet:(%d+)")
+    if petID then return "pet:" .. petID end
+    return itemKey:match("^(%d+)")
+end
+
 local function BuildIndex()
     local log = ns.db and ns.db.log
     if not log then return nil end
@@ -53,6 +64,7 @@ local function BuildIndex()
     local byName = {}   -- lower(name) -> same structure
     local logStats = { sold = 0, active = 0, expired = 0, cancelled = 0, skipped = 0, collected = 0, totalRevenue = 0, totalFees = 0 }
     local uncollected = {}  -- charKey -> { sold, expired, cancelled }
+    local activeByItem = {} -- baseItemID -> { [targetRealm display] = true }
 
     for _, entry in ipairs(log) do
         local key = entry.itemKey
@@ -62,6 +74,17 @@ local function BuildIndex()
         local isFailed = SalesIndex.IsFailed(entry)
         local isActive = SalesIndex.IsActive(entry)
         local soldCopper = isSold and (entry.soldPrice or 0) or 0
+
+        -- Active auctions, indexed by base itemID -> the realms they sit on.
+        -- Keep the raw display realm (not normalized) so connected-realm
+        -- matching via ns:RealmsOverlap works at query time.
+        if isActive then
+            local baseID = BaseItemID(entry.itemKey)
+            if baseID and entry.targetRealm and entry.targetRealm ~= "" then
+                activeByItem[baseID] = activeByItem[baseID] or {}
+                activeByItem[baseID][entry.targetRealm] = true
+            end
+        end
 
         -- Per-item index (by key)
         if key then
@@ -160,6 +183,7 @@ local function BuildIndex()
         byName = byName,
         logStats = logStats,
         uncollected = uncollected,
+        activeByItem = activeByItem,
         builtAt = time(),
     }
 end
@@ -230,6 +254,25 @@ function SalesIndex:GetSalesForRealm(itemKey, itemName, targetRealm)
     local rr = rec.byRealm[realm]
     if not rr or rr.sold == 0 then return 0, 0 end
     return math.floor(rr.revenue / rr.sold), rr.sold
+end
+
+-- True if the player currently has an *active* auction for this item on a
+-- realm sharing a connected-realm AH with targetRealm. Matched at base-itemID
+-- level (across bonus/modifier variants) to agree with the AH-time owned-auction
+-- reconciliation in TrackerAuctions. Used by the Deal Finder to avoid assigning
+-- a deal to a realm where the player is already posted.
+function SalesIndex:HasActiveAuction(itemKey, targetRealm)
+    if not targetRealm or targetRealm == "" then return false end
+    local index = self:EnsureIndex()
+    if not index or not index.activeByItem then return false end
+    local baseID = BaseItemID(itemKey)
+    if not baseID then return false end
+    local realms = index.activeByItem[baseID]
+    if not realms then return false end
+    for postedRealm in pairs(realms) do
+        if ns:RealmsOverlap(postedRealm, targetRealm) then return true end
+    end
+    return false
 end
 
 function SalesIndex:GetLogStats()

--- a/UI/DealFinderDetail.lua
+++ b/UI/DealFinderDetail.lua
@@ -370,6 +370,7 @@ function UI:RenderDealFinderRealmTable(parent, group, numCols, onToggle)
         if realm.isOutlier then table.insert(flags, (C.RED or "") .. "OL|r") end
         if realm.noCompetition then table.insert(flags, (C.GREEN or "") .. "NC|r") end
         if realm.hasPreviousSales then table.insert(flags, (C.YELLOW or "") .. (realm.personalCount or 0) .. "s|r") end
+        if realm.hasActiveAuction then table.insert(flags, "|cffff8800POSTED|r") end
 
         local lbl = Lbl(f, "t", "GameFontHighlightSmall")
         lbl:SetPoint("LEFT", chk, "RIGHT", 4, 0)
@@ -412,6 +413,10 @@ function UI:RenderDealFinderRealmTable(parent, group, numCols, onToggle)
             end
             if ref.noCompetition then
                 GameTooltip:AddLine("No competition on AH", 0.3, 1, 0.3)
+            end
+            if ref.hasActiveAuction then
+                GameTooltip:AddLine("POSTED - you already have an active auction here", 1, 0.53, 0)
+                GameTooltip:AddLine("Demoted in auto-selection; click to override.", 0.7, 0.7, 0.7)
             end
             GameTooltip:Show()
         end)

--- a/UI/DealFinderPage.lua
+++ b/UI/DealFinderPage.lua
@@ -376,8 +376,17 @@ ignoreOutlierChk:SetScript("OnClick", function(self)
     if ns.db then ns.db.settings.dfIgnoreOutliers = self:GetChecked() end
 end)
 
+local avoidPostedChk = CreateFrame("CheckButton", nil, rightCol, "UICheckButtonTemplate")
+avoidPostedChk:SetSize(22, 22); avoidPostedChk:SetPoint("TOPLEFT", ignoreOutlierChk, "BOTTOMLEFT", 0, -2)
+local avoidPostedLbl = rightCol:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+avoidPostedLbl:SetPoint("LEFT", avoidPostedChk, "RIGHT", 2, 0)
+avoidPostedLbl:SetText("Avoid realms where I already have an auction posted")
+avoidPostedChk:SetScript("OnClick", function(self)
+    if ns.db then ns.db.settings.dfAvoidPostedRealms = self:GetChecked() end
+end)
+
 local abbrevPctChk = CreateFrame("CheckButton", nil, rightCol, "UICheckButtonTemplate")
-abbrevPctChk:SetSize(22, 22); abbrevPctChk:SetPoint("TOPLEFT", ignoreOutlierChk, "BOTTOMLEFT", 0, -2)
+abbrevPctChk:SetSize(22, 22); abbrevPctChk:SetPoint("TOPLEFT", avoidPostedChk, "BOTTOMLEFT", 0, -2)
 local abbrevPctLbl = rightCol:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
 abbrevPctLbl:SetPoint("LEFT", abbrevPctChk, "RIGHT", 2, 0)
 abbrevPctLbl:SetText("Abbreviate large profit % (1.5k%, 25M%)")
@@ -964,6 +973,7 @@ function UI:RefreshDealFinderPage()
         if ns.db then
             outlierBox:SetText(tostring(ns.db.settings.dfOutlierMultiplier or 1.5))
             ignoreOutlierChk:SetChecked(ns.db.settings.dfIgnoreOutliers or false)
+            avoidPostedChk:SetChecked(ns.db.settings.dfAvoidPostedRealms ~= false)
             abbrevPctChk:SetChecked(ns.db.settings.dfAbbreviatePct or false)
         end
         local ready = ns.DealFinder and ns.DealFinder:IsReady()


### PR DESCRIPTION
Closes #205.

## Player summary

The Deal Finder no longer sends items to realms you're already selling them on. It now checks what you have posted and steers each item to a realm you're not already on, moving to the next best realm instead. On by default; posted realms are marked **POSTED** in the realm list and stay selectable if you want to add to an existing listing.

---

## Engineering

The Deal Finder scored realms purely on TSM per-realm pricing and never consulted the active-auction log, so it could auto-assign a deal to a realm where the player was already posted. The duplicate was only caught at AH time by `TrackerAuctions:CheckOwnedAuctions` — after the warbank pull and the flight out.

- **SalesIndex** — new `activeByItem` index (base itemID → posted realm display strings) built from `auctionStatus == "active"` entries, plus `HasActiveAuction(itemKey, targetRealm)`. Matches at base-itemID level (mirrors `TrackerAuctions` `EntryItemID`, so it agrees with the AH-time reconciliation across bonus variants) and uses `ns:RealmsOverlap` for connected-realm AHs.
- **DealFinder** — realm options carry `hasActiveAuction`; `ApplyPriority` tracks the best clean (non-posted) realm and selects it when `dfAvoidPostedRealms` is on, falling back to the best posted realm only when every candidate is posted (demote, not drop). `group.selectedPosted` flags the all-posted fallback.
- **DB** — `dfAvoidPostedRealms` default on.
- **UI** — Settings → Deal Finder checkbox; per-realm `POSTED` badge + tooltip in the selection grid, clickable to override.

### Checklist
- [x] Issue linked (#205)
- [x] RELEASES.md + CHANGELOG.md updated (v0.13.0-alpha4)
- [x] `luac -p` clean on all changed files
- [ ] Manual in-game exercise — **F8 waived by maintainer** (published for tester coverage, as alpha3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
