### PR TITLE
fix(FQ-208): treat FP 'Realm 0'/0g buy placeholder as inventory sell

### DIFF
--- a/Import.lua
+++ b/Import.lua
@@ -37,6 +37,24 @@ local function IsFPSourceString(str)
     return FP_SOURCE_STRINGS[str:lower()] or false
 end
 
+-- FlippingPal reuses the cross-realm CSV column layout for its inventory
+-- sell-deal export, padding the buy side with a "Realm 0" / "0g" placeholder
+-- (the item came from the player's own inventory, so there's nothing to buy).
+-- A buy side only counts as a real cross-realm flip when the realm names an
+-- actual realm and the price parses to positive gold — otherwise the row is a
+-- plain sell deal and must not be tagged dealType="flip". Shared by every
+-- parser that detects cross-realm deals (FP comma CSV, tab-delimited, FP
+-- website). See FQ-208.
+local FP_PLACEHOLDER_BUY_REALM = "realm 0"
+
+local function IsRealBuySide(buyRealm, buyPrice)
+    if not buyRealm or buyRealm == "" then return false end
+    if buyRealm:lower() == FP_PLACEHOLDER_BUY_REALM then return false end
+    if IsFPSourceString(buyRealm) then return false end
+    if not buyPrice or buyPrice == "" then return false end
+    return (ns:ParseGoldValue(buyPrice) or 0) > 0
+end
+
 --------------------------
 -- Known WoW values
 --------------------------
@@ -168,8 +186,9 @@ local function ParseRealmLine(realmLine)
         local buyRealm = buyRealmPart:match("^(.-)%s%s+") or buyRealmPart
         buyRealm = CleanRealmString(strtrim(buyRealm))
 
-        -- Check if buyPrice looks like a gold value and buyRealm is a real realm (not a source string)
-        if buyPricePart:match("[%d,]+g") and buyRealm ~= "" and not IsFPSourceString(buyRealm) then
+        -- Cross-realm only when the buy side is a real realm with positive
+        -- gold — not FP's "Realm 0" / "0g" inventory-sell placeholder (FQ-208).
+        if IsRealBuySide(buyRealm, buyPricePart) then
             return sellRealm, buyPricePart, buyRealm
         end
     end
@@ -607,8 +626,7 @@ local function ProcessTabRow(line, colMap, hasCrossRealm)
 
     local key = ns:MakeItemKey(itemID ~= "" and itemID or name, bonusIDs, modifiers)
 
-    local isCrossRealm = buyRealmVal ~= "" and buyPriceVal ~= ""
-        and not IsFPSourceString(buyRealmVal)
+    local isCrossRealm = IsRealBuySide(buyRealmVal, buyPriceVal)
     local dealType = nil
     local profitAmount = nil
     local profitPct = nil
@@ -819,8 +837,7 @@ local function ProcessFPCommaCSVRow(line, colMap, hasCrossRealm)
 
     local key = itemID ~= "" and ns:MakeItemKey(itemID, "", "") or name
 
-    local isCrossRealm = buyRealmVal ~= "" and buyPriceVal ~= ""
-        and not IsFPSourceString(buyRealmVal)
+    local isCrossRealm = IsRealBuySide(buyRealmVal, buyPriceVal)
     local dealType = isCrossRealm and "flip" or "sell"
     local profitAmount = nil
     local profitPct = nil

--- a/test/import_spec.lua
+++ b/test/import_spec.lua
@@ -1,0 +1,117 @@
+-- test/import_spec.lua
+-- Headless tests for FlipQueue's import classification (FQ-208).
+-- Run from the repo root:  lua test/import_spec.lua
+--
+-- Loads the REAL Import.lua against a minimal WoW-API shim plus faithful
+-- copies of the few ns helpers the parse path needs (ParseGoldValue and
+-- MakeItemKey — the two functions the cross-realm-vs-inventory decision
+-- actually depends on). Everything else is stubbed.
+
+-- Resolve paths relative to this script so it runs from any cwd.
+local scriptPath = arg and arg[0] or "test/import_spec.lua"
+local scriptDir = scriptPath:match("^(.*[/\\])") or "./"
+local repoRoot = scriptDir .. ".." .. "/"
+
+dofile(scriptDir .. "wow_shim.lua")
+
+----------------------------------------------------------------------
+-- Build a minimal `ns` with real-enough helpers
+----------------------------------------------------------------------
+local ns = {}
+ns.COLORS = setmetatable({}, { __index = function() return "" end })
+function ns:PrintDebug() end
+function ns:Print() end
+function ns:PrintError() end
+
+-- ParseGoldValue — copied verbatim from DB.lua so "0g" → 0, "1,000g" → 1000,
+-- "13.6k" → 13600, etc. This is the function IsRealBuySide leans on.
+function ns:ParseGoldValue(str)
+    if not str or str == "" then return 0 end
+    local clean = str
+        :gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "")
+        :gsub("%s", "")
+        :gsub("\194\160", ""):gsub("\226\128\175", "")
+        :gsub("\226\128[\139\140\141\142\143]", ""):gsub("\239\187\191", "")
+    local m = clean:match("^([%d,.]+)m")
+    if m then return (tonumber((m:gsub(",", "."))) or 0) * 1000000 end
+    local k = clean:match("^([%d,.]+)k")
+    if k then return (tonumber((k:gsub(",", "."))) or 0) * 1000 end
+    local g = clean:match("([%d,.]+)g")
+    if g then return tonumber((g:gsub("[,.]", ""))) or 0 end
+    return 0
+end
+
+-- MakeItemKey — Cogworks-1.0 Items.lua impl.
+function ns:MakeItemKey(itemID, bonusIDs, modifiers)
+    return string.format("%s;%s;%s", tostring(itemID), bonusIDs or "", modifiers or "")
+end
+function ns:FormatGold(copper) return tostring(copper) .. "g" end
+
+----------------------------------------------------------------------
+-- Load the real Import.lua with the addon vararg contract
+----------------------------------------------------------------------
+local chunk, err = loadfile(repoRoot .. "Import.lua")
+if not chunk then error("could not load Import.lua: " .. tostring(err)) end
+chunk("FlipQueue", ns)
+local Import = ns.Import
+assert(Import, "Import namespace not populated")
+
+----------------------------------------------------------------------
+-- Tiny assert harness
+----------------------------------------------------------------------
+local pass, fail = 0, 0
+local function check(name, cond, detail)
+    if cond then
+        pass = pass + 1
+        print("  ok   " .. name)
+    else
+        fail = fail + 1
+        print("  FAIL " .. name .. (detail and ("  -> " .. detail) or ""))
+    end
+end
+
+----------------------------------------------------------------------
+-- Fixtures
+----------------------------------------------------------------------
+local HEADER = "Item ID,Item Name,Category,ilvl,Sell Rate,Expansion,Quality,Extra Stats,Sale Avg,Sale Avg vs Buy %,Sale Avg vs Buy,Sell vs Buy %,Sell vs Buy,Sell Price,Sell Realm,Buy Price,Buy Realm"
+
+-- Real FP inventory-export rows: every buy side is the "0g / Realm 0"
+-- placeholder. Post-FQ-208 these must classify as sell, not flip.
+local PLACEHOLDER_CSV = HEADER .. "\n" ..
+    '15604,Ancient Defender of the Fireflash,Armor,13,0.01,,uncommon,,707g,707369900.0%,707g,11076315900.0%,"11,076g","11,659g",Stormrage,0g,Realm 0\n' ..
+    'pet_2947,Luminous Webspinner,Pet,,0.013,,,,"4,750g",4749999900.0%,"4,749g",10449049900.0%,"10,449g","10,999g",Tichondrius,0g,Realm 0\n' ..
+    '14794,Protector Ankleguards,Armor,13,0.005,,uncommon,,"1,140g",1140066400.0%,"1,140g",30291291400.0%,"30,291g","31,885g","Aegwynn, Gurubashi, Bonechewer, Hakkar, Garrosh, Daggerspine",0g,Realm 0'
+
+-- Synthetic genuine cross-realm flip: real buy realm + positive buy price.
+-- Must still classify as flip so we don't regress real X-realm imports.
+local REAL_FLIP_CSV = HEADER .. "\n" ..
+    '15604,Ancient Defender of the Fireflash,Armor,13,0.01,,uncommon,,707g,707369900.0%,707g,1107.0%,"11,076g","11,659g",Stormrage,"1,000g",Area 52'
+
+----------------------------------------------------------------------
+-- Tests
+----------------------------------------------------------------------
+print("FQ-208 import classification")
+
+local items = Import:Parse(PLACEHOLDER_CSV)
+check("placeholder CSV parses all 3 rows", #items == 3, "#items=" .. #items)
+local allSell, anyBuyRealm = true, false
+for _, it in ipairs(items) do
+    if it.dealType ~= "sell" then allSell = false end
+    if it.buyRealm and it.buyRealm ~= "" then anyBuyRealm = true end
+end
+check("Realm 0 / 0g rows -> dealType 'sell'", allSell)
+check("Realm 0 / 0g rows -> no buyRealm carried", not anyBuyRealm)
+
+local flips = Import:Parse(REAL_FLIP_CSV)
+check("real X-realm CSV parses 1 row", #flips == 1, "#flips=" .. #flips)
+check("real buy realm + price -> dealType 'flip'", flips[1] and flips[1].dealType == "flip",
+    flips[1] and tostring(flips[1].dealType))
+check("real X-realm -> buyRealm = Area 52", flips[1] and flips[1].buyRealm == "Area 52",
+    flips[1] and tostring(flips[1].buyRealm))
+
+-- Direct ParseGoldValue sanity (the guard's pivot)
+check("ParseGoldValue('0g') == 0", ns:ParseGoldValue("0g") == 0)
+check("ParseGoldValue('1,000g') == 1000", ns:ParseGoldValue("1,000g") == 1000)
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/test/wow_shim.lua
+++ b/test/wow_shim.lua
@@ -1,0 +1,52 @@
+-- test/wow_shim.lua
+-- Minimal stubs for the WoW global API surface that FlipQueue's parsing path
+-- touches, so modules can be loaded and exercised headless under stock
+-- Lua 5.1 (lua.exe). This is a TEST-ONLY shim — it implements just enough of
+-- each global to be behaviourally faithful for parser/classification tests,
+-- not the full Blizzard API. Load this before any FQ module.
+
+-- strtrim(s[, chars]) — trims leading/trailing whitespace (default) or any
+-- char in `chars`. WoW's default trims " \t\r\n".
+function strtrim(s, chars)
+    if s == nil then return "" end
+    if chars then
+        local pat = "^[" .. chars:gsub("(%W)", "%%%1") .. "]*(.-)[" ..
+            chars:gsub("(%W)", "%%%1") .. "]*$"
+        return (s:gsub(pat, "%1"))
+    end
+    return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+-- strsplit(delimiter, str[, limit]) — returns the pieces as multiple return
+-- values. WoW treats every char in `delimiter` as a separator; our callers
+-- only ever pass a single-char delimiter, which this handles faithfully
+-- (including leading/empty/trailing fields).
+function strsplit(delim, str, limit)
+    if delim == "" then return str end
+    local result = {}
+    local escaped = delim:gsub("(%W)", "%%%1")   -- safe inside a [..] set
+    local pat = "(.-)[" .. escaped .. "]"
+    local lastEnd = 1
+    local s, e, cap = str:find(pat, 1)
+    while s do
+        table.insert(result, cap)
+        lastEnd = e + 1
+        s, e, cap = str:find(pat, lastEnd)
+    end
+    table.insert(result, str:sub(lastEnd))
+    return unpack(result)
+end
+
+-- time() / date() — back onto the host os library.
+time = os.time
+date = os.date
+
+-- C_Timer.After(delay, fn) — run synchronously so chunked code paths complete
+-- inline in a test (no frame loop to yield to).
+C_Timer = { After = function(_, fn) if fn then fn() end end }
+
+-- wipe(t) — empty a table in place.
+function wipe(t)
+    for k in pairs(t) do t[k] = nil end
+    return t
+end


### PR DESCRIPTION
Fixes #208.

## Problem

FlippingPal reuses the cross-realm CSV column layout for its **inventory sell-deal** export, padding every row's buy side with a placeholder — `Buy Price=0g`, `Buy Realm=Realm 0` — because the item came from the player's own inventory and has no buy side. FlipQueue's importer treated those populated columns as a genuine cross-realm buy:

```lua
local isCrossRealm = buyRealmVal ~= "" and buyPriceVal ~= ""
    and not IsFPSourceString(buyRealmVal)
```

`"Realm 0"` is non-empty / not an FP source string and `"0g"` is a non-empty string, so every row got tagged `dealType="flip"`, `buyRealm="Realm 0"`. This mislabels inventory sell deals, routes them into `fpCrossRealm`, and — for any deal item no longer held — spawns a bogus "buy on Realm 0" + sell task pair instead of treating it as an inventory sell with no stock. The misclassification happens at parse time, so it fires through the normal Import page (`fpScanner`) too. Surfaced while diagnosing FQ-207.

## Fix

Add a shared `IsRealBuySide(buyRealm, buyPrice)` helper that only treats a buy side as real when the realm names an actual realm (not the `"Realm 0"` sentinel or an FP source string) and the price parses to **positive gold**. Route all three cross-realm detection sites through it:

- `ProcessFPCommaCSVRow` (FP comma CSV)
- `ProcessTabRow` (tab-delimited)
- `ParseRealmLine` (FP website copy-paste)

## Tests

Adds a headless harness (`test/`) — a TEST-ONLY WoW-API shim plus a spec that loads the real `Import.lua` against faithful `ParseGoldValue` + `MakeItemKey` copies:

```
lua test/import_spec.lua   →   8 passed, 0 failed
```

Asserts that `Realm 0 / 0g` rows classify as `sell` (no `buyRealm`) and that genuine cross-realm rows (real realm + positive price) still classify as `flip` with `buyRealm` preserved. Verified under stock Lua 5.1 (`lua.exe` / `luac -p`).

## Note

`"Realm 0"` is treated as FP's sentinel string; worth confirming it's stable (vs. a localized / numeric-id variant) with whoever owns the FP export format — tracked as an open question on #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
