### PR TITLE
fix(FQ-221): logout tool dispatches /logout via secure macrotext

### DIFF
--- a/UI/ToolDrawer.lua
+++ b/UI/ToolDrawer.lua
@@ -662,6 +662,7 @@ function UI:HideToolDrawer()
             btn:SetAttribute("item", nil)
             btn:SetAttribute("spell", nil)
             btn:SetAttribute("macro", nil)
+            btn:SetAttribute("macrotext", nil)
         end
     end
 end
@@ -781,9 +782,13 @@ function UI:RefreshToolDrawer()
 
         -- Secure dispatch (skipped during combat lockdown). Action tools and
         -- unowned services get a cleared button -- PostClick handles them.
+        -- Exception: action tools with a `macrotext` (logout) run protected
+        -- functions, so they dispatch through the secure attribute path.
         if not (InCombatLockdown and InCombatLockdown()) then
             if tool.type == "macro" and not tool.missing then
                 TR:ApplySecureDispatch(btn, "macro", tool.macroName)
+            elseif tool.type == "action" and tool.macrotext then
+                TR:ApplySecureDispatch(btn, "macrotext", tool.macrotext)
             elseif tool.type == "service"
                    and (res.state == "ready" or res.state == "cooldown") then
                 TR:ApplySecureDispatch(btn, res.dispatchKind, res.dispatchName)

--- a/UI/ToolRegistry.lua
+++ b/UI/ToolRegistry.lua
@@ -45,9 +45,12 @@ local BUILTIN_TOOLS = {
     -- Action tools
     --------------------------------------------------------------------
     {
+        -- Logout() is a protected function (ADDON_ACTION_FORBIDDEN from
+        -- insecure code, FQ-221), so this dispatches "/logout" through the
+        -- button's secure macrotext attribute instead of an onUse handler.
         id = "logout", type = "action", label = "Log Out",
         icon = "Interface\\Icons\\INV_Misc_Bell_01",
-        onUse = function() Logout() end,
+        macrotext = "/logout",
         tooltip = "Log out to the character-select screen.",
     },
     {
@@ -613,20 +616,26 @@ function TR:ClassifyEval(e)
 end
 
 -- Apply (or clear) a button's secure click attributes. `kind` is
--- "item" | "spell" | "macro"; pass nil to clear. The caller must guard
--- against combat lockdown -- SetAttribute is protected mid-combat.
+-- "item" | "spell" | "macro" | "macrotext"; pass nil to clear. The caller
+-- must guard against combat lockdown -- SetAttribute is protected mid-combat.
 function TR:ApplySecureDispatch(button, kind, name)
     button:SetAttribute("type", nil)
     button:SetAttribute("item", nil)
     button:SetAttribute("spell", nil)
     button:SetAttribute("macro", nil)
+    button:SetAttribute("macrotext", nil)
     if not (kind and name) then return end
-    button:SetAttribute("type", kind)
     if kind == "spell" then
+        button:SetAttribute("type", "spell")
         button:SetAttribute("spell", name)
     elseif kind == "macro" then
+        button:SetAttribute("type", "macro")
         button:SetAttribute("macro", name)
+    elseif kind == "macrotext" then
+        button:SetAttribute("type", "macro")
+        button:SetAttribute("macrotext", name)
     else
+        button:SetAttribute("type", "item")
         button:SetAttribute("item", name)
     end
 end


### PR DESCRIPTION
Closes #221.

## What

The tools-drawer Log Out button called the protected `Logout()` from an insecure click handler (`ToolRegistry.lua:50`), raising `ADDON_ACTION_FORBIDDEN` on every click.

## How

- Logout tool entry loses its `onUse` and gains `macrotext = "/logout"`.
- `RefreshToolDrawer`'s dispatch branch routes action tools with a `macrotext` through `ApplySecureDispatch`, which now supports a `"macrotext"` kind (`type="macro"` + `macrotext` attribute) — the same secure path player-picked macros already use.
- Both attribute-clearing sites (`ApplySecureDispatch` and `HideToolDrawer`) also clear `macrotext` so pooled buttons can't retain a stale command.

In combat the secure attributes can't be (re)assigned — same standing limitation as the macro/summon tools, and logging out mid-combat is disallowed anyway.

## Test plan

- `luac -p` clean on both files.
- In-game: click Log Out in the tools drawer → character logs out to select screen, no error. Reload UI tool still works. Reorder/hide tools in settings, reopen drawer → logout still fires (pooled-button reassignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)