### PR TITLE
fix(FQ-230): price variant gear per realm instead of falling back region-wide

### DIFF
--- a/DealFinder.lua
+++ b/DealFinder.lua
@@ -276,12 +276,21 @@ function DealFinder:ScanChunked(pool, onProgress, onComplete)
                 local targetRealm = realmInfo.display
                 local pricing = FindRealmPricing(allRealmPrices, targetRealm)
 
-                local tsmPrice, numAuctions, dataQuality
+                local tsmPrice, numAuctions, dataQuality, approxSource, approxIlvl
 
                 if pricing then
                     tsmPrice = pricing.marketValueRecent or pricing.minBuyout
                     numAuctions = pricing.numAuctions
-                    dataQuality = "perRealm"
+                    -- "nearestIlvl"/"baseItem" are this realm's own pricing but
+                    -- for a neighbouring variant, so they carry realm-to-realm
+                    -- signal while still being approximate — worth showing, and
+                    -- worth labelling. See TSMRealms:GetBatchPricing.
+                    if pricing.source == "nearestIlvl" or pricing.source == "baseItem" then
+                        dataQuality = "perRealmApprox"
+                        approxSource = pricing.source
+                    else
+                        dataQuality = "perRealm"
+                    end
                 elseif regionMarketAvg and regionMarketAvg > 0 then
                     tsmPrice = regionMarketAvg
                     dataQuality = "regional"
@@ -326,6 +335,8 @@ function DealFinder:ScanChunked(pool, onProgress, onComplete)
                             hasPreviousSales = (personalCount or 0) > 0,
                             hasActiveAuction = ns.SalesIndex:HasActiveAuction(itemKey, targetRealm),
                             dataQuality   = dataQuality or "perRealm",
+                            approxSource  = approxSource,
+                            approxIlvl    = approxIlvl,
                             score         = 0,  -- set by ApplyPriority
                         })
                     end

--- a/TSMRealms.lua
+++ b/TSMRealms.lua
@@ -226,10 +226,11 @@ end
 -- On-demand item lookup
 --------------------------
 
--- Search a realm's raw item-data string for a specific item. Tries both the
--- given form and (if applicable) the level form, since TSM stores variants
--- under the level form in its per-realm AuctionDB.
--- Returns decoded field values or nil.
+-- Search a realm's raw item-data string for a specific item. Tries the given
+-- form, then the level form, then (for variant gear) the nearest recorded
+-- item level, then the base item — see the resolution ladder documented on
+-- GetBatchPricing.
+-- Returns decoded field values plus the match source, or nil.
 local function FindItemInRaw(rawEntry, tsmItemStr)
     if not rawEntry or not rawEntry.str then return nil end
 
@@ -247,13 +248,44 @@ local function FindItemInRaw(rawEntry, tsmItemStr)
         local escaped = tsmItemStr:gsub("([%.%+%-%*%?%[%]%^%$%(%)%%])", "%%%1")
         otherData = rawEntry.str:match('{"' .. escaped .. '",([^}]+)}')
     end
+    local source = otherData and "exact" or nil
+
+    local baseID = tsmItemStr:match("^i:(%d+)")
+    local wantIlvl, matchedIlvl
     if not otherData then
         -- Try the level form before giving up.
         local levelStr = ToLevelForm(tsmItemStr)
         if levelStr and levelStr ~= tsmItemStr then
+            wantIlvl = tonumber(levelStr:match("::i(%d+)$"))
             local escapedLevel = levelStr:gsub("([%.%+%-%*%?%[%]%^%$%(%)%%])", "%%%1")
             otherData = rawEntry.str:match('{"' .. escapedLevel .. '",([^}]+)}')
+            if otherData then source = "exact" end
         end
+    end
+    if not otherData and baseID then
+        -- Nearest recorded item level for this base item. TSM's per-realm
+        -- AuctionDB records whatever ilvl each scanner's client reported, so
+        -- one item routinely occupies several level-form keys and our single
+        -- computed ilvl need not be among them.
+        local bestDelta
+        for ilvlStr, values in rawEntry.str:gmatch('{"i:' .. baseID .. '::i(%d+)",([^}]+)}') do
+            local ilvl = tonumber(ilvlStr)
+            if ilvl then
+                local delta = wantIlvl and math.abs(ilvl - wantIlvl) or 0
+                if not bestDelta or delta < bestDelta then
+                    bestDelta = delta
+                    otherData = values
+                    matchedIlvl = ilvl
+                end
+            end
+        end
+        if otherData then source = "nearestIlvl" end
+    end
+    if not otherData and baseID then
+        -- Base item. Coarser than the variant, but it is this realm's own
+        -- pricing rather than a region-wide average across every realm.
+        otherData = rawEntry.str:match("{" .. baseID .. ",([^}]+)}")
+        if otherData then source = "baseItem" end
     end
     if not otherData then return nil end
 
@@ -263,7 +295,7 @@ local function FindItemInRaw(rawEntry, tsmItemStr)
     for i = 1, #parts do
         result[i] = DecodeValue(parts[i])
     end
-    return result
+    return result, source, matchedIlvl
 end
 
 --------------------------
@@ -285,6 +317,31 @@ function TSMRealms:GetRealmList()
     return realmList
 end
 
+-- Every distinct item level this base item is recorded under, across all
+-- captured realms, sorted ascending. Diagnostic support for /fq debug
+-- pricing: our derived level form is a single guess, and TSM's data can hold
+-- many buckets for one item, so a lookup miss needs to be readable as "wrong
+-- bucket" rather than "no data". Returns an empty table when the item is
+-- stored by plain ID only.
+function TSMRealms:GetRecordedItemLevels(baseID)
+    local seen, out = {}, {}
+    if not isLoaded or not baseID then return out end
+    for _, realm in ipairs(realmList) do
+        local rawEntry = realmRaw[realm]
+        if rawEntry and rawEntry.str then
+            for ilvlStr in rawEntry.str:gmatch('{"i:' .. baseID .. '::i(%d+)"') do
+                local ilvl = tonumber(ilvlStr)
+                if ilvl and not seen[ilvl] then
+                    seen[ilvl] = true
+                    out[#out + 1] = ilvl
+                end
+            end
+        end
+    end
+    table.sort(out)
+    return out
+end
+
 function TSMRealms:GetRealmUpdateTime(realmName)
     local r = realmRaw[realmName]
     return r and r.downloadTime
@@ -304,7 +361,7 @@ function TSMRealms:GetAllRealmPricing(itemString)
     local result = {}
     for _, realm in ipairs(realmList) do
         local rawEntry = realmRaw[realm]
-        local values = FindItemInRaw(rawEntry, itemString)
+        local values, source, matchedIlvl = FindItemInRaw(rawEntry, itemString)
         if values then
             local fl = rawEntry.fieldLookup
             local minBuyout = fl.minBuyout and values[fl.minBuyout]
@@ -317,6 +374,8 @@ function TSMRealms:GetAllRealmPricing(itemString)
                     numAuctions = (numAuctions and numAuctions > 0) and numAuctions or nil,
                     marketValueRecent = (recent and recent > 0) and recent or nil,
                     updateTime = rawEntry.downloadTime,
+                    source = source,
+                    matchedIlvl = matchedIlvl,
                 }
             end
         end
@@ -377,21 +436,38 @@ end
 --   at every item match).
 --
 -- Returns: { [tsmItemString] = { [realmName] = { minBuyout, numAuctions,
---             marketValueRecent, updateTime } } }
+--             marketValueRecent, updateTime, source } } }
+--
+-- `source` records which rung of the resolution ladder produced the price:
+-- "exact" (the variant we asked for), "nearestIlvl" (another recorded item
+-- level of the same item) or "baseItem" (the base item's own listings).
+--
+-- The ladder exists because TSM's per-realm AuctionDB stores variant gear
+-- ONLY in level form ("i:258955::i171") — there is not a single bonus-form
+-- key in the dataset. Worse, the item level TSM records is whatever the
+-- scanning client reported, and the auction house reports item levels SCALED
+-- TO THE VIEWING CHARACTER, so one item routinely occupies many level-form
+-- keys (item 258955 appears at ilvl 133/139/152/158/165/171/192/198/220 on a
+-- single realm; 45% of gear items carry more than one). Our locally computed
+-- ilvl is therefore one guess against up to nine buckets, and a miss used to
+-- drop the item all the way to the region-wide average on EVERY realm —
+-- which is exactly the "same price on all realms" report in FQ-230.
+-- Measured on a live 40-realm AppData: every gear item that appears in level
+-- form also has a plain base-item entry, so rung 3 always has something.
 function TSMRealms:GetBatchPricing(itemStrings)
     local result = {}
     if not isLoaded or not itemStrings or #itemStrings == 0 then return result end
 
-    -- Two lookup sets: numeric IDs (for "i:NNNN" plain items) and the full
-    -- quoted form (for items with bonus/modifier tails like "i:225575::2:1663:2293").
-    --
-    -- For variant items, also try the LEVEL FORM ("i:225575::i253") since
-    -- that's how TSM stores them in its per-realm AuctionDB. Both forms get
-    -- registered; whichever matches first wins, and the quotedToOriginal
-    -- map back-translates a level-form hit to the caller's original key.
+    -- Lookup sets: numeric IDs (for "i:NNNN" plain items), the full quoted
+    -- form (for items with bonus/modifier tails like "i:225575::2:1663:2293"),
+    -- and — for variant gear — the base item ID, which drives the nearest-ilvl
+    -- and base-item rungs of the ladder below.
     local wantedIDs = {}             -- numericID string -> tsmItemString
-    local wantedQuoted = {}          -- full tsmItemString -> true
-    local quotedToOriginal = {}      -- level-form string -> caller's input string
+    local wantedQuoted = {}          -- exact/level form -> caller's input string
+    local wantedBase = {}            -- baseID string -> array of caller input strings
+    local variantBase = {}           -- caller input string -> baseID string
+    local targetIlvl = {}            -- caller input string -> ilvl we computed
+    local anyVariant = false
     local emptyResult = {}           -- shared empty default for items with no hits
     for _, str in ipairs(itemStrings) do
         if str then
@@ -399,11 +475,24 @@ function TSMRealms:GetBatchPricing(itemStrings)
             if id then
                 wantedIDs[id] = str
             else
-                wantedQuoted[str] = true
+                wantedQuoted[str] = str
                 local levelStr = ToLevelForm(str)
                 if levelStr and levelStr ~= str then
-                    wantedQuoted[levelStr] = true
-                    quotedToOriginal[levelStr] = str
+                    wantedQuoted[levelStr] = str
+                    targetIlvl[str] = tonumber(levelStr:match("::i(%d+)$"))
+                end
+                -- Pets ("p:1965") have no base ID here by design — they are
+                -- matched only in exact form, exactly as before.
+                local baseID = str:match("^i:(%d+)")
+                if baseID and not variantBase[str] then
+                    variantBase[str] = baseID
+                    local list = wantedBase[baseID]
+                    if not list then
+                        list = {}
+                        wantedBase[baseID] = list
+                    end
+                    list[#list + 1] = str
+                    anyVariant = true
                 end
             end
             result[str] = nil  -- placeholder so callers can distinguish
@@ -419,36 +508,127 @@ function TSMRealms:GetBatchPricing(itemStrings)
             local fRecent = fl.marketValueRecent
             local downloadTime = rawEntry.downloadTime
 
+            -- Decode just the values we care about (minBuyout, numAuctions,
+            -- marketValueRecent). Avoid the cost of decoding every column.
+            -- Returns nil when the entry carries no usable price.
+            local function Decode(valuesPart)
+                local parts = { strsplit(",", valuesPart) }
+                local minBuyout   = fMin and parts[fMin] and DecodeValue(parts[fMin]) or nil
+                local numAuctions = fNum and parts[fNum] and DecodeValue(parts[fNum]) or nil
+                local recent      = fRecent and parts[fRecent] and DecodeValue(parts[fRecent]) or nil
+                if (minBuyout and minBuyout > 0) or (recent and recent > 0) then
+                    return minBuyout, numAuctions, recent
+                end
+                return nil
+            end
+
+            -- Per-realm accumulators for the fallback rungs. Only the exact
+            -- rung writes straight through; the others need the whole realm
+            -- walked before the best candidate is known.
+            local lvlMin, lvlNum, lvlRecent, lvlDelta, lvlAt = {}, {}, {}, {}, {}
+            local baseMin, baseNum, baseRecent = {}, {}, {}
+
             -- Walk every item entry in the realm string exactly once.
             -- Format is `{itemPart,values}` where itemPart is either a numeric
             -- itemID or a quoted "itemString". Values are comma-separated
             -- base-32 encoded numbers; brace nesting doesn't occur in values.
             for itemPart, valuesPart in rawEntry.str:gmatch("{([^,]+),([^}]+)}") do
-                local key
                 if itemPart:sub(1, 1) == '"' then
-                    -- Quoted item string variant. If this matches a level
-                    -- form we registered, back-translate to the caller's
-                    -- original input key so result[] uses their key.
+                    -- Quoted item string variant. wantedQuoted maps both the
+                    -- bonus form and the level form back to the caller's key.
                     local stripped = itemPart:sub(2, -2)
-                    if wantedQuoted[stripped] then
-                        key = quotedToOriginal[stripped] or stripped
+                    local key = wantedQuoted[stripped]
+                    if key then
+                        local minBuyout, numAuctions, recent = Decode(valuesPart)
+                        if minBuyout or recent then
+                            local entry = result[key]
+                            if not entry then
+                                entry = {}
+                                result[key] = entry
+                            end
+                            entry[realm] = {
+                                minBuyout = (minBuyout and minBuyout > 0) and minBuyout or nil,
+                                numAuctions = (numAuctions and numAuctions > 0) and numAuctions or nil,
+                                marketValueRecent = (recent and recent > 0) and recent or nil,
+                                updateTime = downloadTime,
+                                source = "exact",
+                            }
+                        end
+                    elseif anyVariant then
+                        -- Not the exact key we computed, but possibly another
+                        -- recorded item level of an item we want.
+                        local bid, ilvlStr = stripped:match("^i:(%d+)::i(%d+)$")
+                        local wanters = bid and wantedBase[bid]
+                        if wanters then
+                            local ilvl = tonumber(ilvlStr)
+                            local minBuyout, numAuctions, recent = Decode(valuesPart)
+                            if ilvl and (minBuyout or recent) then
+                                for i = 1, #wanters do
+                                    local k = wanters[i]
+                                    local want = targetIlvl[k]
+                                    local delta = want and math.abs(ilvl - want) or 0
+                                    if lvlDelta[k] == nil or delta < lvlDelta[k] then
+                                        lvlDelta[k] = delta
+                                        lvlMin[k] = minBuyout
+                                        lvlNum[k] = numAuctions
+                                        lvlRecent[k] = recent
+                                        lvlAt[k] = ilvl
+                                    end
+                                end
+                            end
+                        end
                     end
                 else
-                    -- Plain numeric ID
-                    key = wantedIDs[itemPart]
+                    -- Plain numeric ID: serves both plain inputs (exact) and
+                    -- variant inputs (base-item fallback).
+                    local key = wantedIDs[itemPart]
+                    local wanters = anyVariant and wantedBase[itemPart] or nil
+                    if key or wanters then
+                        local minBuyout, numAuctions, recent = Decode(valuesPart)
+                        if minBuyout or recent then
+                            if key then
+                                local entry = result[key]
+                                if not entry then
+                                    entry = {}
+                                    result[key] = entry
+                                end
+                                entry[realm] = {
+                                    minBuyout = (minBuyout and minBuyout > 0) and minBuyout or nil,
+                                    numAuctions = (numAuctions and numAuctions > 0) and numAuctions or nil,
+                                    marketValueRecent = (recent and recent > 0) and recent or nil,
+                                    updateTime = downloadTime,
+                                    source = "exact",
+                                }
+                            end
+                            if wanters then
+                                baseMin[itemPart] = minBuyout
+                                baseNum[itemPart] = numAuctions
+                                baseRecent[itemPart] = recent
+                            end
+                        end
+                    end
                 end
+            end
 
-                if key then
-                    -- Decode just the values we care about (minBuyout,
-                    -- numAuctions, marketValueRecent). Avoid the cost of
-                    -- decoding every column.
-                    local parts = { strsplit(",", valuesPart) }
-                    local minBuyout   = fMin and parts[fMin] and DecodeValue(parts[fMin]) or nil
-                    local numAuctions = fNum and parts[fNum] and DecodeValue(parts[fNum]) or nil
-                    local recent      = fRecent and parts[fRecent] and DecodeValue(parts[fRecent]) or nil
-
-                    if (minBuyout and minBuyout > 0) or (recent and recent > 0) then
-                        local entry = result[key]
+            -- Resolution ladder for variant gear on this realm, best first:
+            --   1. exact      — already written above
+            --   2. nearestIlvl — another recorded item level of the same item
+            --   3. baseItem    — the base item's own listings on this realm
+            -- Anything still unresolved falls to DealFinder's region-wide
+            -- average, which is what made every realm show one price.
+            for key, baseID in pairs(variantBase) do
+                local entry = result[key]
+                if not (entry and entry[realm]) then
+                    local minBuyout, numAuctions, recent, source, matchedIlvl
+                    if lvlDelta[key] ~= nil then
+                        minBuyout, numAuctions, recent = lvlMin[key], lvlNum[key], lvlRecent[key]
+                        source = "nearestIlvl"
+                        matchedIlvl = lvlAt[key]
+                    elseif baseMin[baseID] ~= nil or baseRecent[baseID] ~= nil then
+                        minBuyout, numAuctions, recent = baseMin[baseID], baseNum[baseID], baseRecent[baseID]
+                        source = "baseItem"
+                    end
+                    if source then
                         if not entry then
                             entry = {}
                             result[key] = entry
@@ -458,6 +638,8 @@ function TSMRealms:GetBatchPricing(itemStrings)
                             numAuctions = (numAuctions and numAuctions > 0) and numAuctions or nil,
                             marketValueRecent = (recent and recent > 0) and recent or nil,
                             updateTime = downloadTime,
+                            source = source,
+                            matchedIlvl = matchedIlvl,
                         }
                     end
                 end

--- a/UI/DealFinderDetail.lua
+++ b/UI/DealFinderDetail.lua
@@ -406,8 +406,23 @@ function UI:RenderDealFinderRealmTable(parent, group, numCols, onToggle)
                     G(rp) .. " (" .. ((ref.realProfitPct or 0) >= 0 and "+" or "") .. ns:FormatPctNum(ref.realProfitPct or 0) .. "%)",
                     0.7,0.7,0.7, rp > 0 and 0.3 or 1, rp > 0 and 1 or 0.3, 0.3)
             end
-            GameTooltip:AddDoubleLine("Data Source", ref.dataQuality == "perRealm" and "Per-Realm TSM" or "Regional Fallback",
-                0.7,0.7,0.7, 0.6,0.6,0.6)
+            local srcLabel = "Regional Fallback"
+            if ref.dataQuality == "perRealm" then
+                srcLabel = "Per-Realm TSM"
+            elseif ref.dataQuality == "perRealmApprox" then
+                srcLabel = (ref.approxSource == "baseItem")
+                    and "Per-Realm TSM (base item)"
+                    or "Per-Realm TSM (nearest item level)"
+            end
+            GameTooltip:AddDoubleLine("Data Source", srcLabel, 0.7,0.7,0.7, 0.6,0.6,0.6)
+            if ref.dataQuality == "perRealmApprox" then
+                GameTooltip:AddLine("This realm's own pricing, but for a close variant", 0.8, 0.7, 0.4)
+                if ref.approxIlvl then
+                    GameTooltip:AddLine("(matched at item level " .. ref.approxIlvl .. ")", 0.8, 0.7, 0.4)
+                else
+                    GameTooltip:AddLine("rather than this exact item level.", 0.8, 0.7, 0.4)
+                end
+            end
             if ref.isOutlier then
                 GameTooltip:AddLine("OUTLIER - Price exceeds regional threshold", 1, 0.3, 0.3)
             end
@@ -580,7 +595,9 @@ function UI:RenderDealFinderResearch(parent, group)
         TblRow({
             name = rn, tsm = G(realm.tsmPrice), blend = G(realm.blendedPrice),
             ah = tostring(realm.numAuctions or 0), sold = soldStr,
-            src = (realm.dataQuality == "perRealm") and "Realm" or "|cffaa6666Rgn|r",
+            src = (realm.dataQuality == "perRealm") and "Realm"
+                or (realm.dataQuality == "perRealmApprox") and "|cffccaa55Realm~|r"
+                or "|cffaa6666Rgn|r",
             spread = spreadStr,
         }, nil, ri % 2 == 0 and {0.06, 0.06, 0.08, 0.3} or nil)
     end

--- a/UI/SlashCommands.lua
+++ b/UI/SlashCommands.lua
@@ -1177,6 +1177,20 @@ local function debugPricing(rawQuery)
             L("(no TSM string — lookup not possible)")
             return
         end
+        -- The level form we derive is one guess; TSM records whatever item
+        -- level each scanning client reported, so the same item can occupy
+        -- several level-form keys. List what's actually stored so a miss is
+        -- visible as "wrong bucket" rather than "no data" (FQ-230).
+        if ns.TSMRealms.GetRecordedItemLevels then
+            local baseID = tsmStr:match("^i:(%d+)")
+            local levels = baseID and ns.TSMRealms:GetRecordedItemLevels(baseID)
+            if levels and #levels > 0 then
+                L("recorded ilvls: " .. table.concat(levels, ", ") ..
+                    "  (across all captured realms)")
+            elseif baseID then
+                L("recorded ilvls: (none — this item is stored by plain ID only)")
+            end
+        end
         local pricing = ns.TSMRealms:GetAllRealmPricing(tsmStr) or {}
         local hits, misses = 0, 0
         local realms = ns.TSMRealms:GetRealmList() or {}
@@ -1186,8 +1200,8 @@ local function debugPricing(rawQuery)
                 hits = hits + 1
                 local mb = p.minBuyout and ns:FormatGold(p.minBuyout) or "?"
                 local mvr = p.marketValueRecent and ns:FormatGold(p.marketValueRecent) or "?"
-                L(string.format("  HIT  %-20s minBuyout=%s recent=%s n=%s",
-                    realmName, mb, mvr, tostring(p.numAuctions)))
+                L(string.format("  HIT  %-20s minBuyout=%s recent=%s n=%s via=%s",
+                    realmName, mb, mvr, tostring(p.numAuctions), p.source or "exact"))
             else
                 misses = misses + 1
                 L(string.format("  miss %s", realmName))
@@ -1215,7 +1229,8 @@ local function debugPricing(rawQuery)
                     end
                 end
                 if resolved then
-                    L(string.format("    %-22s Per-Realm TSM (via %s)", info.display, via))
+                    L(string.format("    %-22s Per-Realm TSM (via %s, match=%s)",
+                        info.display, via, resolved.source or "exact"))
                 else
                     L(string.format("    %-22s REGIONAL FALLBACK", info.display))
                 end

--- a/test/tsmrealms_spec.lua
+++ b/test/tsmrealms_spec.lua
@@ -1,0 +1,187 @@
+-- test/tsmrealms_spec.lua
+-- Headless coverage for TSMRealms' per-realm pricing lookup (FQ-230).
+--
+-- Run from the repo root with stock Lua 5.1:
+--   "C:\Program Files (x86)\Lua\5.1\lua.exe" test/tsmrealms_spec.lua
+--
+-- What this pins down: TSM's per-realm AuctionDB stores variant gear ONLY in
+-- level form ("i:222::i100"), and the item level it records is whatever the
+-- scanning client reported — which the auction house scales to the viewing
+-- character. Our locally derived item level is therefore one guess among
+-- several recorded buckets, and before FQ-230 a miss dropped the item to the
+-- region-wide average on EVERY realm (the "same price on all realms" report).
+-- The fixtures below mirror the real AppData shapes verified against a live
+-- 40-realm TradeSkillMaster_AppHelper/AppData.lua.
+
+dofile("test/wow_shim.lua")
+
+--------------------------
+-- Harness
+--------------------------
+
+local passed, failed = 0, 0
+local function check(label, got, want)
+    if got == want then
+        passed = passed + 1
+    else
+        failed = failed + 1
+        print(string.format("  FAIL %s\n       got:  %s\n       want: %s",
+            label, tostring(got), tostring(want)))
+    end
+end
+
+-- GetDetailedItemLevelInfo is what ToLevelForm leans on. Tests drive it
+-- directly to model both a correct resolve and the player-scaled miss.
+local stubIlvl = nil
+function GetDetailedItemLevelInfo(_) return stubIlvl end
+
+local ns = {}
+function ns:PrintDebug(_) end
+
+local chunk = assert(loadfile("TSMRealms.lua"))
+chunk("FlipQueue", ns)
+local TSMRealms = ns.TSMRealms
+
+--------------------------
+-- Fixtures
+--------------------------
+
+-- Base-32 encoded values, as TSM ships them: A=10, K=20, U=30, 1=1, 2=2.
+-- Fields are {itemString, minBuyout, numAuctions, marketValueRecent}, the
+-- exact field list AUCTIONDB_NON_COMMODITY_DATA carries in the wild.
+local function AppData(entries)
+    return 'return {downloadTime=1784604337,fields={"itemString","minBuyout"' ..
+        ',"numAuctions","marketValueRecent"},data={' .. entries .. '}}'
+end
+
+-- Alpha:   item 222 recorded at ilvl 100 AND 120, plus a base entry
+-- Bravo:   item 222 recorded at ilvl 110 only, plus a base entry
+-- Charlie: item 222 has a base entry only (no level form at all)
+local FIXTURES = {
+    { "Alpha",   AppData('{111,A,2,K},{"i:222::i100",A,1,A},{"i:222::i120",K,1,K},{222,U,3,U},{"p:1965",A,1,A}') },
+    { "Bravo",   AppData('{111,K,2,K},{"i:222::i110",U,1,U},{222,A,3,A}') },
+    { "Charlie", AppData('{111,U,2,U},{222,K,3,K}') },
+}
+
+for _, f in ipairs(FIXTURES) do
+    TSM_APPHELPER_LOAD_DATA("AUCTIONDB_NON_COMMODITY_DATA", f[1], f[2])
+end
+-- Region-wide tags must be ignored — commodities are region-wide by design.
+TSM_APPHELPER_LOAD_DATA("AUCTIONDB_NON_COMMODITY_DATA", "US", AppData('{999,A,1,A}'))
+TSM_APPHELPER_LOAD_DATA("AUCTIONDB_COMMODITY_DATA", "Alpha", AppData('{888,A,1,A}'))
+
+__testFireEvent(__testFrames[1], "PLAYER_LOGIN")
+
+print("TSMRealms spec")
+check("captured 3 realms (US and commodity data ignored)", #TSMRealms:GetRealmList(), 3)
+check("is loaded", TSMRealms:IsLoaded(), true)
+
+--------------------------
+-- Batch path
+--------------------------
+
+local function batch(keys)
+    TSMRealms:InvalidateCache()
+    return TSMRealms:GetBatchPricing(keys)
+end
+
+local function src(res, key, realm)
+    local perRealm = res[key]
+    local entry = perRealm and perRealm[realm]
+    return entry and entry.source or nil
+end
+local function minBuyout(res, key, realm)
+    local perRealm = res[key]
+    local entry = perRealm and perRealm[realm]
+    return entry and entry.minBuyout or nil
+end
+
+-- 1. Plain item: matched by numeric ID on every realm, unchanged behaviour.
+local r = batch({ "i:111" })
+check("plain/Alpha source", src(r, "i:111", "Alpha"), "exact")
+check("plain/Bravo source", src(r, "i:111", "Bravo"), "exact")
+check("plain/Charlie value", minBuyout(r, "i:111", "Charlie"), 30)
+
+-- 2. Variant gear, derived ilvl lands exactly on a recorded bucket (100).
+--    Alpha matches exactly; Bravo has only ilvl 110 -> nearest; Charlie has
+--    no level form at all -> base item. Before FQ-230, Bravo and Charlie
+--    both returned nothing and fell to the region-wide average.
+stubIlvl = 100
+r = batch({ "i:222::2:1663" })
+check("variant-exact/Alpha source", src(r, "i:222::2:1663", "Alpha"), "exact")
+check("variant-exact/Alpha value", minBuyout(r, "i:222::2:1663", "Alpha"), 10)
+check("variant-exact/Bravo source", src(r, "i:222::2:1663", "Bravo"), "nearestIlvl")
+check("variant-exact/Bravo value", minBuyout(r, "i:222::2:1663", "Bravo"), 30)
+check("variant-exact/Charlie source", src(r, "i:222::2:1663", "Charlie"), "baseItem")
+check("variant-exact/Charlie value", minBuyout(r, "i:222::2:1663", "Charlie"), 20)
+
+-- 3. Player-scaled miss: derived ilvl 115 exists on no realm. Alpha must
+--    pick 120 (delta 5) over 100 (delta 15) — nearest, not first-seen.
+--    (Each case uses its own bonus tail: ToLevelForm memoizes per item
+--    string for the session, so reusing one key would reuse its ilvl.)
+stubIlvl = 115
+r = batch({ "i:222::2:1664" })
+check("scaled-miss/Alpha source", src(r, "i:222::2:1664", "Alpha"), "nearestIlvl")
+check("scaled-miss/Alpha picks ilvl 120", minBuyout(r, "i:222::2:1664", "Alpha"), 20)
+check("scaled-miss/Bravo source", src(r, "i:222::2:1664", "Bravo"), "nearestIlvl")
+check("scaled-miss/Charlie source", src(r, "i:222::2:1664", "Charlie"), "baseItem")
+
+-- 4. Item level cannot be derived at all (item not in the client cache).
+--    Every rung below "exact" must still produce a per-realm price.
+stubIlvl = nil
+r = batch({ "i:222::2:1665" })
+check("no-ilvl/Alpha resolves", src(r, "i:222::2:1665", "Alpha"), "nearestIlvl")
+check("no-ilvl/Bravo resolves", src(r, "i:222::2:1665", "Bravo"), "nearestIlvl")
+check("no-ilvl/Charlie resolves", src(r, "i:222::2:1665", "Charlie"), "baseItem")
+
+-- 5. Pets carry no base ID: exact match only, no fallback invented.
+stubIlvl = 100
+r = batch({ "p:1965" })
+check("pet/Alpha source", src(r, "p:1965", "Alpha"), "exact")
+check("pet/Bravo no fallback", src(r, "p:1965", "Bravo"), nil)
+
+-- 6. Unknown item stays empty rather than borrowing another item's price.
+r = batch({ "i:777::2:1663" })
+check("unknown/Alpha empty", src(r, "i:777::2:1663", "Alpha"), nil)
+check("unknown returns a table", type(r["i:777::2:1663"]), "table")
+
+-- 7. Mixed pool in one call: every input keeps its own key and ladder.
+r = batch({ "i:111", "i:222::2:1663", "p:1965" })
+check("mixed/plain", src(r, "i:111", "Bravo"), "exact")
+check("mixed/variant", src(r, "i:222::2:1663", "Alpha"), "exact")
+check("mixed/pet", src(r, "p:1965", "Alpha"), "exact")
+
+--------------------------
+-- Non-batch path (GetAllRealmPricing) must climb the same ladder
+--------------------------
+
+stubIlvl = 115
+TSMRealms:InvalidateCache()
+local all = TSMRealms:GetAllRealmPricing("i:222::2:1666")
+check("single/Alpha source", all.Alpha and all.Alpha.source, "nearestIlvl")
+check("single/Alpha picks ilvl 120", all.Alpha and all.Alpha.minBuyout, 20)
+check("single/Bravo source", all.Bravo and all.Bravo.source, "nearestIlvl")
+check("single/Charlie source", all.Charlie and all.Charlie.source, "baseItem")
+
+stubIlvl = 100
+TSMRealms:InvalidateCache()
+all = TSMRealms:GetAllRealmPricing("i:222::2:1667")
+check("single-exact/Alpha source", all.Alpha and all.Alpha.source, "exact")
+
+TSMRealms:InvalidateCache()
+all = TSMRealms:GetAllRealmPricing("i:111")
+check("single-plain/Charlie value", all.Charlie and all.Charlie.minBuyout, 30)
+
+--------------------------
+-- Diagnostic support
+--------------------------
+
+local levels = TSMRealms:GetRecordedItemLevels("222")
+check("recorded ilvls count", #levels, 3)
+check("recorded ilvls sorted", table.concat(levels, ","), "100,110,120")
+check("plain item has no recorded ilvls", #TSMRealms:GetRecordedItemLevels("111"), 0)
+
+--------------------------
+
+print(string.format("\n%d passed, %d failed", passed, failed))
+os.exit(failed == 0 and 0 or 1)

--- a/test/wow_shim.lua
+++ b/test/wow_shim.lua
@@ -50,3 +50,23 @@ function wipe(t)
     for k in pairs(t) do t[k] = nil end
     return t
 end
+
+-- CreateFrame(...) — a frame stub that records its scripts and registered
+-- events so a test can drive event handlers by hand. Every frame created is
+-- appended to _G.__testFrames; fire one with __testFireEvent(frame, event).
+__testFrames = {}
+function CreateFrame(_, _, _, _)
+    local frame = { _scripts = {}, _events = {} }
+    function frame:SetScript(kind, fn) self._scripts[kind] = fn end
+    function frame:GetScript(kind) return self._scripts[kind] end
+    function frame:RegisterEvent(event) self._events[event] = true end
+    function frame:UnregisterEvent(event) self._events[event] = nil end
+    function frame:UnregisterAllEvents() self._events = {} end
+    table.insert(__testFrames, frame)
+    return frame
+end
+
+function __testFireEvent(frame, event, ...)
+    local fn = frame._scripts and frame._scripts.OnEvent
+    if fn then fn(frame, event, ...) end
+end


### PR DESCRIPTION
Closes #230.

## What was wrong

Deal Finder showed the same price on every realm for nearly every item the reporter held (transmog gear — "out of the 100-1000s of items there is 2-3 that have different prices").

Both standing theories are dead:

- **Not the load-order hook miss** from the original engineering note. His log carries `TSMRealms: loaded pricing for 12 realms`, which is the `#realmList > 0` branch — AppData was captured.
- **Not the commodity split (#235).** His items are transmog gear, which is non-commodity. #235 is a real but separate defect.

## Root cause

Verified against a live 40-realm `TradeSkillMaster_AppHelper/AppData.lua`:

1. **TSM stores variant gear only in level form** (`i:258955::i171`). There is not one bonus-form key in the whole per-realm dataset, so the bonus form `TSM_API.ToItemString` gives us can never match. Everything rode on `ToLevelForm`'s single derived item level.
2. **That derived level is one guess among many.** TSM records whatever item level each scanning client reported, and the AH scales item levels to the viewing character — the same pathology as FQ-227, one layer down. **45% of gear items (731/1641) occupy more than one bucket**; item 258955 alone spans ilvl 133/139/152/158/165/171/192/198/220.
3. A miss dropped the item to `DBRegionMarketAvg` on **every** realm — the reported symptom exactly.

The 2-3 items that did work for him are plain items with no bonus IDs, which match by numeric ID and never touch this path.

## The fix

`GetBatchPricing` and `FindItemInRaw` now climb a ladder per realm before surrendering to the regional average:

1. `exact` — the level form we derived
2. `nearestIlvl` — the closest recorded item level for the same base item
3. `baseItem` — the base item's own listings on that realm

Each hit carries a `source`, so approximate matches are labelled rather than passing as exact. Measured on the real AppData, 12 realms × 400 gear items:

| scenario | per-realm coverage | items regional on *every* realm |
|---|---|---|
| derived ilvl hits a recorded bucket | 41.5% → **84.9%** | 0% → 0% |
| ilvl scaled off the buckets (FQ-227 case) | 19.8% → **84.9%** | 69.5% → **0%** |
| ilvl underivable (item not cached) | 0% → **84.9%** | 100% → **0%** |

The residual ~15% is items genuinely absent from that realm's data — correct behaviour. A 2,500-item pool over 12 realms went from **34** per-realm hits to **12,375**, costing **0.071s → 0.211s** once per scan.

## Also in here

- **UI:** approximate matches show `Realm~` in the detail source column (vs `Realm` / `Rgn`) and name their matched item level in the tooltip.
- **Diagnostics:** `/fq debug pricing` now lists the item levels TSM actually holds for the item, and reports which rung each realm resolved through. A miss now reads as "wrong bucket" instead of "no data" — which is why the dumps we asked for could never have shown this.

## Tests

`test/tsmrealms_spec.lua` — 34 assertions under stock Lua 5.1, run from the repo root:

```
"C:\Program Files (x86)\Lua\5.1\lua.exe" test/tsmrealms_spec.lua
```

Covers all three rungs, the player-scaled miss, nearest-not-first-seen selection, and that plain items, pets and unknown items are unaffected. `test/wow_shim.lua` gains a `CreateFrame` stub so event-driven modules load headless. `test/import_spec.lua` still passes.

## Test plan (in game — NOT yet done)

- [ ] `/fq debug pricing` + shift-click a transmog item: `recorded ilvls` line appears; sell realms show `match=exact|nearestIlvl|baseItem`
- [ ] Deal Finder scan: gear items now show differing prices across realms rather than one repeated value
- [ ] Detail view: approximate rows read `Realm~` and the tooltip names the matched item level
- [ ] A plain (no-bonus) item and a battle pet still price exactly as before
- [ ] Scan time on a large pool is not noticeably worse

## Player summary

Deal Finder was showing the same price on every realm for most gear, because it could only recognise an item at one exact item level and gear is listed at many. It now falls back to the closest item level TSM has for that item, and only uses a region-wide average as a last resort — so realm-to-realm price differences show up for transmog and other gear. Prices matched this way are marked so you can tell them apart at a glance.